### PR TITLE
specify freenode.net IRC servers

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -9,8 +9,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 
 * http://groups.google.com/group/clojure[Clojure Google Group]
-
-* #clojure on IRC
+* #clojure IRC channel on https://freenode.net[freenode.net]
 * http://clojurians.net[Clojurians Slack Chat]
 * http://dev.clojure.org/display/community/Home[Community Wiki]
 * http://dev.clojure.org/display/doc/Home[Documentation Wiki]


### PR DESCRIPTION
IRC is just the protocol, we need to specify which server(s).

p.s. CA is under "Maximilien Penet" 