### PR TITLE
cljs api -> cljs cheatsheet

### DIFF
--- a/content/api/api.adoc
+++ b/content/api/api.adoc
@@ -15,7 +15,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 == ClojureScript API
 
-* http://cljs.info/[ClojureScript API]
+* http://cljs.info/cheatsheet/[ClojureScript Cheatsheet]
 
 == Clojure Contrib Libraries
 


### PR DESCRIPTION
At the moment the link  for cljs info end up redirecting to the cheatsheet.
So it's miss leading expecting an api and getting a document called cheatsheet