### PR TITLE
Add Parens of the Dead to the Guides section

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -86,6 +86,7 @@ Community:
 * Newsletters - http://defnewsletter.com/[(def newsletter)] http://www.clojuregazette.com/[Clojure Gazette] http://reborg.tumblr.com/[Clojure Weekly]
 * http://www.clojureatlas.com/[Clojure Atlas] - visualization of Clojure and the core library
 * http://www.clojurebridge.org/[ClojureBridge] - beginner workshops for women
+* http://www.parens-of-the-dead.com/[Parens of the Dead] - a screencast series writing a game from scratch with Clojure and ClojureScript
 
 Videos and presentations:
 


### PR DESCRIPTION
Maybe it would fit better under "Video training", but it's not "(commercial)", so I placed it under "Community" instead. Hope you think it worthy of inclusion.