### PR TITLE
Add Boot to Clojure Tools

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -35,6 +35,7 @@ Try Clojure online:
 Community volunteers maintain http://dev.clojure.org/display/doc/getting+started[Getting Started] documentation for a number of different tools and approaches. Some of the most commonly used tools include:
 
 * http://leiningen.org/[Leiningen] - an extensible build tool that provides dependency management, REPL support, testing, packaging, deployment, and many other capabilities.
+* http://boot-clj.com/[Boot] - build tooling for Clojure: instead of a special-purpose DSL, Boot supplies abstractions and libraries you can use to automate nearly any build scenario with the full power of the Clojure language
 * http://www.gnu.org/software/emacs/[Emacs] with https://github.com/clojure-emacs/cider[CIDER]
 * http://www.vim.org/[Vim] with https://github.com/tpope/vim-fireplace[Fireplace]
 * https://code.google.com/p/counterclockwise/[Eclipse Counterclockwise]


### PR DESCRIPTION
I think Boot has been around long enough and it is stable / powerful enough to warrant a mention right up there with Leiningen on the Getting Started page.