### PR TITLE
Add docs for setting compiler settings in Leiningen

### DIFF
--- a/content/reference/compilation.adoc
+++ b/content/reference/compilation.adoc
@@ -73,6 +73,8 @@ Alternately, compiler options can also be set via the Java system properties at 
 * `-Dclojure.compiler.elide-meta="[:doc :file :line :added]"`
 * `-Dclojure.compiler.direct-linking=true`
 
+To set these compiler options in other tools, see the docs for setting JVM options in https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md#setting-jvm-options[Leiningen] and https://github.com/boot-clj/boot/wiki/JVM-Options[Boot].
+
 See below for more info on each of these options.
 
 === Locals clearing

--- a/content/reference/repl_and_main.adoc
+++ b/content/reference/repl_and_main.adoc
@@ -131,6 +131,8 @@ Following is an example of starting a socket server with a repl listener. This c
 -Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"
 ----
 
+To start a socket REPL in other tools, see the docs for setting JVM options in https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md#setting-jvm-options[Leiningen] and https://github.com/boot-clj/boot/wiki/JVM-Options[Boot].
+
 An example client you can use to connect to this socket repl is telnet:
 
 [source,clojure]


### PR DESCRIPTION
I took a look at the boot docs and wasn't sure how to set the JVM opts for the running application. Possibly @micha might be able to provide guidance on this for Boot?
