### PR TITLE
Fix typo extra paren transients example

### DIFF
--- a/content/reference/transients.adoc
+++ b/content/reference/transients.adoc
@@ -62,7 +62,7 @@ Here's a very typical example, some code that builds up a vector for return, all
 
 ;; benchmarked (Java 1.8, Clojure 1.7)
 (def v (vrange 1000000))    ;; 73.7 ms
-(def v2 (vrange2 1000000))) ;; 19.7 ms
+(def v2 (vrange2 1000000))  ;; 19.7 ms
 ----
 Oh, yeah, _**transients are fast!**_
 


### PR DESCRIPTION
This change fixes a typo.

Note (I've tried this twice): I am replacing a single `)` with a space ` ` on line 65, but the GitHub UI seems to think I'm also making a non-change on line 92. (It must be whitespace I can't see.)