### PR TITLE
this "when to use section" is misleading

### DIFF
--- a/content/reference/reducers.adoc
+++ b/content/reference/reducers.adoc
@@ -84,9 +84,3 @@ Specify a reduce function and a combine function with fold:
 (defn word-frequency [text]
   (r/fold merge-counts count-words (clojure.string/split text #"\s+")))
 ----
-== When to use
-Use the reducer form of these operations when:
-
-* Source data can be generated and held in memory
-* Work to be performed is computation (not I/O or blocking)
-* Number of data items or work to be done is "large"


### PR DESCRIPTION
I think a when to use section would be nice to have, but the current one only makes sense as a set of restrictions applied to fold, not reducers in generally. 

If you look at http://clojure.com/blog/2012/05/08/reducers-a-library-and-model-for-collection-processing.html under the heading "More Opportunity (i.e. Work)" rhickey explicitly called out reducers as a mechanism for solving "the lazily dangling open resource problem"