### PR TITLE
Update spec.adoc to add namespace to `instrument`

### DIFF
--- a/content/guides/spec.adoc
+++ b/content/guides/spec.adoc
@@ -593,7 +593,7 @@ We can turn on instrumentation (spec checking) with:
 
 [source,clojure]
 ----
-(instrument #'ranged-rand)
+(s/instrument #'ranged-rand)
 ----
 
 If the args are invalid you'll see an error like this:


### PR DESCRIPTION
`instrument` is missing the spec namespace alias