### PR TITLE
Update spec.adoc to add an empty set-config defn

### DIFF
--- a/content/guides/spec.adoc
+++ b/content/guides/spec.adoc
@@ -538,6 +538,8 @@ Here we conform using the config specification defined above:
 
 [source,clojure]
 ----
+(defn set-config [k v] ...)
+
 (defn configure [input]
   (let [parsed (s/conform ::config input)]
     (if (= parsed ::s/invalid)


### PR DESCRIPTION
This is another take on https://github.com/clojure/clojure-site/pull/108
I'm trying to help beginners with this. Right now lots of experienced people are using this but I don't expect this in the future.
Someone could be surprised and have a hard time understanding why this is failing. If you fell another way please close this and I will stop trying ;)