### PR TITLE
fix syntax-quote header in reader.adoc

### DIFF
--- a/content/reference/reader.adoc
+++ b/content/reference/reader.adoc
@@ -128,7 +128,8 @@ where args are determined by the presence of argument literals taking the form %
 +
 The form following pass:[#_] is completely skipped by the reader. (This is a more complete removal than the http://clojure.github.io/clojure/clojure.core-api.html#clojure.core/comment[comment] macro which yields nil).
 
-=== [[syntax-quote]] Syntax-quote (`, note, the "backquote" character), Unquote (~) and Unquote-splicing (~@)
+[[syntax-quote]]
+=== Syntax-quote (`, note, the "backquote" character), Unquote (~) and Unquote-splicing (~@)
 
 For all forms other than Symbols, Lists, Vectors, Sets and Maps, `x is the same as 'x. +
 


### PR DESCRIPTION
The following link navigates you to the ToC bar instead of the header itself:
http://clojure.org/reference/reader#syntax-quote

The asciidoc syntax for explicit section ids was just slightly off.