### PR TITLE
Change i.e. -> e.g. and also mention let

### DIFF
--- a/content/reference/evaluation.adoc
+++ b/content/reference/evaluation.adoc
@@ -29,7 +29,7 @@ A Symbol is _resolved_:
 * Else, it is not qualified and the first of the following applies:
 . If it names a special form it is considered a special form, and must be utilized accordingly.
 . A lookup is done in the current namespace to see if there is a mapping from the symbol to a class. If so, the symbol is considered to name a Java class object. Note that class names normally denote class objects, but are treated specially in certain special forms, e.g. `.` and `new`.
-. If in a local scope (i.e. in a function definition), a lookup is done to see if it names a local binding (e.g. a function argument or let-bound name). If so, the value is the value of the local binding.
+. If in a local scope (e.g. in a function definition or a let form), a lookup is done to see if it names a local binding (e.g. a function argument or let-bound name). If so, the value is the value of the local binding.
 . A lookup is done in the current namespace to see if there is a mapping from the symbol to a var. If so, the value is the value of the binding of the var referred-to by the symbol.
 . It is an error.
 


### PR DESCRIPTION
It is referring to function definitions as an example, but i.e. is not appropriate.
Included let forms in the example to make it consistent with the "(e.g. a function argument or let-bound name)" that follows.