### PR TITLE
adds clojurebridge minneapolis and san francisco workshops

### DIFF
--- a/content/events/2016/clojurebridge_minneapolis.adoc
+++ b/content/events/2016/clojurebridge_minneapolis.adoc
@@ -1,0 +1,16 @@
+= ClojureBridgeMN - Fall 2016
+ClojureBridge
+2016-11-04
+:jbake-type: event
+:jbake-edition: 2016
+:jbake-link: http://www.clojurebridge.org/events/2016-11-04-minneapolis-mn
+:jbake-location: Minneapolis, MN
+:jbake-start: 2016-11-04
+:jbake-end: 2016-11-05
+
+ClojureBridge aims to increase diversity within the Clojure community by offering free, beginner-friendly Clojure programming workshops for underrepresented groups in tech.
+
+We'll meet up Friday night to install all of the software you need on your laptop, and then spend Saturday learning and writing code:
+
+- Track1: simple application
+- Track2: basic syntax, data structure and more

--- a/content/events/2016/clojurebridge_sanfrancisco.adoc
+++ b/content/events/2016/clojurebridge_sanfrancisco.adoc
@@ -1,0 +1,13 @@
+= ClojureBridge San Francisco - Programming Workshop
+ClojureBridge
+2016-10-21
+:jbake-type: event
+:jbake-edition: 2016
+:jbake-link: http://www.clojurebridge.org/events/2016-10-21-san-francisco
+:jbake-location: San Francisco, CA
+:jbake-start: 2016-10-21
+:jbake-end: 2016-10-22
+
+ClojureBridge, a free 1-day workshop aimed at increasing the participation of women in the Clojure community, will be held in San Francisco on Saturday October 22 2016 with an optional install fest on Friday October 21 2016 in the late afternoon. The workshop is intended both for those new to programming, as well as those with some programming experience, who would like to explore programming using Clojure, a modern functional programming language.
+
+The workshop will introduce you to fundamental programming concepts and approaches. Participants can choose between two tracks, based on their programming experience.


### PR DESCRIPTION
I'd like to add two ClojureBridge workshops scheduled recently, Minneapolis, MN and San Francisco, CA.