### PR TITLE
Adds ClojureBridge London and Berlin

### DIFF
--- a/content/events/2016/clojurebridge_berlin_2.adoc
+++ b/content/events/2016/clojurebridge_berlin_2.adoc
@@ -1,0 +1,13 @@
+= ClojureBridge Berlin Germany
+ClojureBridge
+2016-11-25
+:jbake-type: event
+:jbake-edition: 2016
+:jbake-link: http://www.clojurebridge.org/events/2016-11-25-berlin
+:jbake-location: Berlin, Germany
+:jbake-start: 2016-11-25
+:jbake-end: 2016-11-26
+
+We are offing this workshop to help make the Clojure community more accessible to a diverse range of participants. As such, registration is open to people who identify as a woman or have a nonbinary gender identity. Note that our coaches and organizers who will also be present at the event are members of the local Clojure community of various genders.
+
+We'll meet up Friday late afternoon to install all of the software you need, and then spend Saturday learning and writing code. You will learn and practice in small groups of 2 to 4 attendees each.

--- a/content/events/2016/clojurebridge_london_3.adoc
+++ b/content/events/2016/clojurebridge_london_3.adoc
@@ -1,0 +1,15 @@
+= ClojureBridge London - November 2016
+ClojureBridge
+2016-11-15
+:jbake-type: event
+:jbake-edition: 2016
+:jbake-link: http://www.clojurebridge.org/events/2016-11-25-london
+:jbake-location: London, UK
+:jbake-start: 2016-11-25
+:jbake-end: 2016-11-26
+
+ClojureBridge London aims to further increase diversity within the Clojure community by offering free, beginner-friendly Clojure programming workshops for under-represented groups in technology. Priority is given to those who identify as women, trans-gener or non-binary gender. Males may register as a guest of one of these participants.
+
+Its essential to attend the evening session on the 25th November if you wish to attend the workshop the next day. This avoids delays to getting started with the workshop.
+
+Food and drinks will be provided throughout the event, so please let us know if you have any special requirements when you register.


### PR DESCRIPTION
ClojureBridge London and Berlin are scheduled on Nov 25-26. Please add these two in upcoming events section.