### PR TITLE
Adds ClojureBridge Buenos Aires

### DIFF
--- a/content/events/2017/clojurebridge-ba.adoc
+++ b/content/events/2017/clojurebridge-ba.adoc
@@ -1,0 +1,11 @@
+= ClojureBridge Buenos Aires
+ClojureBridge Buenos Aires
+2017-03-10
+:jbake-type: event
+:jbake-edition: 2017
+:jbake-link: http://bridge.clojureba.com/
+:jbake-location: Buenos Aires, Argentina
+:jbake-start: 2017-03-10
+:jbake-end: 2017-03-11
+
+The first workshop of ClojureBridge Buenos Aires (and first in South America)!


### PR DESCRIPTION
ClojureBridge Buenos Aires is scheduled for March 10th & 11th. More info: http://bridge.clojureba.com. It would be great to have it listed in the events section :)