### PR TITLE
Spec Guide: Correct explain output for keys spec failure

### DIFF
--- a/content/guides/spec.adoc
+++ b/content/guides/spec.adoc
@@ -243,7 +243,10 @@ When conformance is checked on a map, it does two things - checking that the req
 (s/explain ::person
   {::first-name "Elon"})
 ;; val: #:my.domain{:first-name "Elon"} fails spec: :my.domain/person
-;;  predicate: [(contains? % :my.domain/last-name) (contains? % :my.domain/email)]
+;;  predicate: (contains? % :my.domain/last-name)
+;; val: #:my.domain{:first-name "Elon"} fails spec: :my.domain/person
+;;  predicate: (contains? % :my.domain/email)
+
 
 ;; Fails attribute conformance
 (s/explain ::person
@@ -288,7 +291,9 @@ Let's consider a person map that uses unqualified keys but checks conformance ag
 (s/explain :unq/person
   {:first-name "Elon"})
 ;; val: {:first-name "Elon"} fails spec: :unq/person
-;;   predicate: [(contains? % :last-name) (contains? % :email)]
+;;  predicate: (contains? % :last-name)
+;; val: {:first-name "Elon"} fails spec: :unq/person
+;;  predicate: (contains? % :email)
 ----
 
 Unqualified keys can also be used to validate record attributes:


### PR DESCRIPTION
When following the guide using the current version of Clojure (`1.9.0-alpha14`) I get different explain output to what the guide presents.

When evaluating:
```clojure
(def email-regex #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$")
(s/def ::email-type (s/and string? #(re-matches email-regex %)))
(s/def ::acctid int?)
(s/def ::first-name string?)
(s/def ::last-name string?)
(s/def ::email ::email-type)
(s/def ::person (s/keys :req [::first-name ::last-name ::email] :opt [::phone]))
(s/explain ::person  {::first-name "Elon"})
```

Rather than a single message with a combined predicate:
```
val: #:my.domain{:first-name "Elon"} fails spec: :my.domain/person predicate: [(contains? % :my.domain/last-name) (contains? % :my.domain/email)]
```

I get one message, and predicate, per missing key:
```
val: #:my.domain{:first-name "Elon"} fails spec: :my.domain/person predicate: (contains? % :my.domain/last-name)
val: #:my.domain{:first-name "Elon"} fails spec: :my.domain/person predicate: (contains? % :my.domain/email)
```

I'm guessing explain behavior for keys specs has changed in a recent release.