### PR TITLE
Spec Guide: Fix stest/check success return value

### DIFF
--- a/content/guides/spec.adoc
+++ b/content/guides/spec.adoc
@@ -1194,10 +1194,9 @@ We mentioned earlier that `clojure.spec.test` provides tools for automatically t
 
 (stest/check `ranged-rand)
 ;;=> ({:spec #object[clojure.spec$fspec_impl$reify__13728 0x4a47e374 "clojure.spec$fspec_impl$reify__13728@4a47e374"],
-;;     :clojure.spec.test.check/ret {:result true, :num-tests 100, :seed 1466805740290},
+;;     :clojure.spec.test.check/ret {:result true, :num-tests 1000, :seed 1466805740290},
 ;;     :sym spec.examples.guide/ranged-rand,
-;;     :result true,
-;;     :type :pass})
+;;     :result true})
 ----
 
 `check` also takes a number of options that can be passed to test.check to influence the test run, as well as the option to override generators for parts of the spec, by either name or path.


### PR DESCRIPTION
On success, in Clojure `1.9.0-alpha14`, `(stest/check)` returns a map with `(:spec :clojure.spec.test.check/ret :sym)` keys. It doesn't have a `:result` key.

Also, the default `num-tests` is now `[1000](https://github.com/clojure/clojure/blob/c0326d2386dd1227f35f46f1c75a8f87e2e93076/src/clj/clojure/spec/test.clj#L304)`, not `100`.