### PR TITLE
Clarify member access/dot special forms

### DIFF
--- a/content/reference/java_interop.adoc
+++ b/content/reference/java_interop.adoc
@@ -49,6 +49,8 @@ The preferred idiomatic forms for accessing field or method members are given ab
 Classname/staticField ==> (. Classname staticField)
 ----
 
+The next section explains the behavior of those expanded forms in more detail.
+
 == The Dot special form
 
 [%hardbreaks]
@@ -62,7 +64,15 @@ Special form.
 
 The '.' special form is the basis for access to Java. It can be considered a member-access operator, and/or read as 'in the scope of'.
 
-If the first operand is a symbol that resolves to a class name, the access is considered to be to a static member of the named class. Note that nested classes are named EnclosingClass$NestedClass, per the JVM spec. Otherwise it is presumed to be an instance member and the first argument is evaluated to produce the target object.
+If the first operand is a symbol that resolves to a class name, the access is considered to be to a static member of the named class. Note that nested classes are named EnclosingClass$NestedClass, per the JVM spec. Otherwise it is presumed to be an instance member and the first argument is evaluated to produce the target object. For example:
+
+`(. String getName)`
+
+fails because _**String**_ is a symbol that resolves to a class name and this is treated as a static member access, but
+
+`(. (identity String) getName)`
+
+succeeds because _**(identity String)**_ is not a symbol and is therefore evaluated to produce an object of type _**Class**_, and the instance member _**getName**_ is called upon it. This is why _**(.getName String)**_, in _Member access_ above, expands to include a call to _**identity**_.
 
 If the second operand is a symbol and no args are supplied it is taken to be a field access - the name of the field is the name of the symbol, and the value of the expression is the value of the field, _unless_ there is a no argument public method of the same name, in which case it resolves to a call to the method. If the second operand is a symbol starting with _-_, the member-symbol will resolve only as field access (never as a 0-arity method) and should be preferred when that is the intent.
 


### PR DESCRIPTION
Addresses #171 by attempting to clarify the member access and dot special form sections, for classes.

Added paragraph linking **Member access** section to **The Dot special form** section, so it's clearer that the behavior of member access is determined by the semantics of the dot special form.

In _The Dot special form_, added the example from #171 after explanation of the first operand, showing why `(. String getName)` would fail but `(. (identity String) getName)` would succeed, with a reference back to `(.instanceMember Classname)` in _Member access_.