### PR TITLE
add ClojureBridge SF 09/16/17 event

### DIFF
--- a/content/events/2017/clojurebridge-sanfrancisco.adoc
+++ b/content/events/2017/clojurebridge-sanfrancisco.adoc
@@ -1,0 +1,13 @@
+= ClojureBridge San Francisco
+ClojureBridge
+2017-09-16
+:jbake-type: event
+:jbake-edition: 2017
+:jbake-link: http://www.clojurebridge.org/events/2017-09-16-san-francisco
+:jbake-location: San Francisco, CA
+:jbake-start: 2017-09-15
+:jbake-end: 2017-09-16
+
+ClojureBridge is a free 1-day workshop aimed at increasing the participation of women, trans-gener and non-binary gender individuals in the Clojure community. The workshop is intended for those new to programming as well as individuals with some programming experience who would like to explore programming using Clojure, a modern functional programming language.
+
+The workshop will introduce participants to fundamental programming concepts and approaches.


### PR DESCRIPTION
So we're hosting ClojureBridge in SF on 09/16/17!

Here is the link to eventbrite: https://www.eventbrite.com/e/clojurebridge-intro-to-programming-workshop-tickets-36278581213

Link to ClojureBridge Workshop PR: https://github.com/ClojureBridge/Workshops/issues/61
