### PR TITLE
Update clojurebridge sf 2017 url

### DIFF
--- a/content/events/2017/clojurebridge-sanfrancisco.adoc
+++ b/content/events/2017/clojurebridge-sanfrancisco.adoc
@@ -1,9 +1,9 @@
 = ClojureBridge San Francisco
 ClojureBridge San Francisco
-2017-09-16
+2017-09-15
 :jbake-type: event
 :jbake-edition: 2017
-:jbake-link: http://www.clojurebridge.org/events/2017-09-16-san-francisco
+:jbake-link: http://www.clojurebridge.org/events/2017-09-15-san-francisco
 :jbake-location: San Francisco, CA
 :jbake-start: 2017-09-15
 :jbake-end: 2017-09-16


### PR DESCRIPTION
SF Clojurebridge 2017 link is created per https://github.com/ClojureBridge/Workshops/issues/61#issuecomment-319347795. This PR is to conform the URL to http://www.clojurebridge.org/events/2017-09-15-san-francisco