### PR TITLE
Replace "+" with "addition"

### DIFF
--- a/content/guides/learn/syntax.adoc
+++ b/content/guides/learn/syntax.adoc
@@ -92,7 +92,7 @@ In the diagram, (+ 3 4) is read as a list containing the symbol (+) and two numb
 Considering the evaluation of the expression above:
 
 * 3 and 4 evaluate to themselves (longs)
-* + evaluates to a function that implements +
+* + evaluates to a function that implements addition
 * evaluating the list will invoke the + function with 3 and 4 as arguments
 
 Many languages have both statements and expressions, where statements have some stateful effect but do not return a value. In Clojure, everything is an expression that evaluates to a value. Some expressions (but not most) also have side effects.


### PR DESCRIPTION
It looks like asciidoc treats a plus sign at the end of a line specially (http://asciidoctor.org/docs/asciidoc-writers-guide/#wrapped-text-and-hard-line-breaks), so the plus isn't showing up on the web page (https://clojure.org/guides/learn/syntax). Regardless, it seems less confusing to use the full word "addition", rather than using "+" to refer to both the var and the concept of addition in the same sentence.