### PR TITLE
Explicit example of 1-arity return type hint

### DIFF
--- a/content/reference/java_interop.adoc
+++ b/content/reference/java_interop.adoc
@@ -259,6 +259,10 @@ For function return values, the type hint can be placed before the arguments vec
 
 [source,clojure]
 ----
+(defn hinted-single ^String [])
+
+-> #user/hinted-single
+
 (defn hinted
   (^String [])
   (^Integer [a])


### PR DESCRIPTION
To an experienced Clojure user it is clear that `(defn hinted-single ^String [])` is equivalent to `(defn hinted-single (^String []))` but it isn't so obvious to somebody less experienced, especially one used to the fact that function and type declaration is "magic" and not simply a reuse of mechanisms used in user code (namely metadata and metadata reader macro). So providing an explicit example will help them a lot to relate it to their code (that rarely uses multiple arities).