### PR TITLE
Fix example for Java instance method

### DIFF
--- a/content/guides/learn/functions.adoc
+++ b/content/guides/learn/functions.adoc
@@ -275,7 +275,7 @@ Below is a summary of calling conventions for calling into Java from Clojure:
 |===
 | Task | Java | Clojure |
 |Instantiation| `new Widget("foo")` | `(Widget. "foo")` | 
-|Instance method| `rnd.next()` | `(.nextInt rnd)` |
+|Instance method| `rnd.next()` | `(.next rnd)` |
 |Instance field| `object.field` | `(.-field object)` |
 |Static method| `Math.sqrt(25)` | `(Math/sqrt 25)` |
 |Static field| `Math.PI` | `Math/PI` |


### PR DESCRIPTION
The methods on the left and right should be the same

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
