### PR TITLE
Fix bullet list formatting in Learn Functions exercises 10 and 12

### DIFF
--- a/content/guides/learn/functions.adoc
+++ b/content/guides/learn/functions.adoc
@@ -398,6 +398,7 @@ In Clojure, this is the complement function.
 ----
 
 10) Using the http://docs.oracle.com/javase/8/docs/api/java/lang/Math.html[java.lang.Math] class (`Math/pow`, `Math/cos`, `Math/sin`, `Math/PI`), demonstrate the following mathematical facts:
+
 * The cosine of pi is -1
 * For some x, sin(x)^2 + cos(x)^2 = 1
 
@@ -419,6 +420,7 @@ In fact, the Clojure `slurp` function interprets its argument as a URL first bef
 ----
 
 12) Define a function `one-less-arg` that takes two arguments:
+
 * `f`, a function
 * `x`, a value
 


### PR DESCRIPTION
This adds an extra space between the exercise text and the bulleted list items. Without it, they aren't rendered as list items, but just plain text as part of the previous line.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
