### PR TITLE
"Thread isolation level" in transients' summary

### DIFF
--- a/content/reference/transients.adoc
+++ b/content/reference/transients.adoc
@@ -78,7 +78,6 @@ Transients provide a high-performance optimization of functional data-structure-
 
 
 * Single-path use
-* Thread isolation - enforced
 * O(1) creation from persistent data structures
 * Shares structure with persistent source
 * O(1) creation of persistent data structure when editing session finished


### PR DESCRIPTION
The summary says "Thread isolation - enforced" while a note above it says "That check was removed in 1.7 to ..." so thread isolation is no longer enforced.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
