### PR TITLE
Re-ordered resolving of (not package-qualified symbols): Local scope …

### DIFF
--- a/content/reference/evaluation.adoc
+++ b/content/reference/evaluation.adoc
@@ -26,10 +26,10 @@ A Symbol is _resolved_:
 
 * If it is namespace-qualified, the value is the value of the binding of the global var named by the symbol. It is an error if there is no global var named by the symbol, or if the reference is to a non-public var in a different namespace.
 * If it is package-qualified, the value is the Java class named by the symbol. It is an error if there is no Class named by the symbol.
-* Else, it is not qualified and the first of the following applies:
+* Else, it is not qualified and the first applicable of the following applies:
 . If it names a special form it is considered a special form, and must be utilized accordingly.
-. A lookup is done in the current namespace to see if there is a mapping from the symbol to a class. If so, the symbol is considered to name a Java class object. Note that class names normally denote class objects, but are treated specially in certain special forms, e.g. `.` and `new`.
 . If in a local scope (e.g. in a function definition or a let form), a lookup is done to see if it names a local binding (e.g. a function argument or let-bound name). If so, the value is the value of the local binding.
+. A lookup is done in the current namespace to see if there is a mapping from the symbol to a class. If so, the symbol is considered to name a Java class object. Note that class names normally denote class objects, but are treated specially in certain special forms, e.g. `.` and `new`.
 . A lookup is done in the current namespace to see if there is a mapping from the symbol to a var. If so, the value is the value of the binding of the var referred-to by the symbol.
 . It is an error.
 


### PR DESCRIPTION
…before a (Java) class. Why? Because: (let [Object 1] Object) returns 1, not java.lang.Object

- [x ] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [ x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
