### PR TITLE
Add note for Local Build about prerequisites

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -55,6 +55,8 @@ Not yet available - see Leiningen or Boot instead.
 
 *Local build*
 
+Note: this assumes you have Java, Git, and Ant installed locally.
+
 Download and build Clojure from source:
 
 [source,shell]


### PR DESCRIPTION
Based on a discussion on #beginners on Clojurians Slack, it needs to be clearer that this section is only intended for people who want to build Clojure locally, so they don't skip to just the `java -jar` part.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
