### PR TITLE
Link Leiningen and Boot in the Windows section

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -49,7 +49,7 @@ Platform installers (apt-get, etc) will be available in the future.
 
 === Installation on Windows
 
-Not yet available - see Leiningen or Boot instead.
+Not yet available - see https://leiningen.org/[Leiningen] or http://boot-clj.com/[Boot] instead.
 
 == Other ways to run Clojure
 


### PR DESCRIPTION
Whilst they are both linked in the Build Tools section at the bottom of the page, Windows users might not read that far. Linking them where they are mentioned in the Windows section will make it easier for Windows beginners to navigate to the appropriate tools, until the PowerShell version of the CLI tools is available.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
