### PR TITLE
Fix link to "start your own group"

### DIFF
--- a/content/community/user_groups.adoc
+++ b/content/community/user_groups.adoc
@@ -8,7 +8,7 @@ Erik Assum
 ifdef::env-github,env-browser[:outfilessuffix: .adoc]
 
 Do you wish there was a Clojure User Group in your area? Check
-out our page of <<start_group,tips for starting your own>>
+out our page of link:start_group[tips for starting your own]
 
 If you'd like to have your group listed here, please submit a PR against the
 https://github.com/clojure/clojure-site[clojure-site] github repo.


### PR DESCRIPTION
Old link used fragment syntax, content is now in a separate document.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
