### PR TITLE
Fix with-gen code

### DIFF
--- a/content/guides/spec.adoc
+++ b/content/guides/spec.adoc
@@ -1137,7 +1137,7 @@ Returning to our "hello" example, we now have the tools to make that generator:
 (s/def ::hello
   (s/with-gen #(clojure.string/includes? % "hello")
     #(gen/fmap (fn [[s1 s2]] (str s1 "hello" s2))
-      (gen/tuple (gen/string-alphanumeric) (gen/string-alphanumeric)))))
+      (gen/tuple gen/string-alphanumeric gen/string-alphanumeric))))
 (gen/sample (s/gen ::hello))
 ;;=> ("hello" "ehello3" "eShelloO1" "vhello31p" "hello" "1Xhellow" "S5bhello" "aRejhellorAJ7Yj" "3hellowPMDOgv7" "UhelloIx9E")
 ----


### PR DESCRIPTION
The existing with-gen example wraps unary test.check generators but this doesn't work, unwrapping these generators fixes the issue.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
