### PR TITLE
Pre conditions throw errors

### DIFF
--- a/content/reference/special_forms.adoc
+++ b/content/reference/special_forms.adoc
@@ -176,7 +176,7 @@ The __condition-map__ parameter may be used to specify pre- and post-conditions 
 
 where either key is optional. The condition map may also be provided as metadata of the arglist.
 
-_pre-expr_ and _post-expr_ are boolean expressions that may refer to the parameters of the function. In addition, `%` may be used in a _post-expr_ to refer to the function's return value. If any of the conditions evaluate to `false` and `pass:[*assert*]` is true, an assertion failure exception is thrown.
+_pre-expr_ and _post-expr_ are boolean expressions that may refer to the parameters of the function. In addition, `%` may be used in a _post-expr_ to refer to the function's return value. If any of the conditions evaluate to `false` and `pass:[*assert*]` is true, a Java `java.lang.AssertionError` is thrown.
 
 Example:
 [source,clojure]


### PR DESCRIPTION
The object thrown by `:pre` and `:post` conditions is not a subclass of Exception, it's an Error, and thus will not be caught with the `try/catch Exception` idiom. Update the docs to reflect this.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
