### PR TITLE
Add link Rationale->Getting Started

### DIFF
--- a/content/about/rationale.adoc
+++ b/content/about/rationale.adoc
@@ -125,4 +125,4 @@ and couldn't find one. Here's an outline of some of the motivating ideas behind 
 * Locking is too hard to get right over and over again
 * Clojure's software transactional memory and agent systems do the hard part
 
-In short, I think Clojure occupies a unique niche as a functional Lisp for the JVM with strong concurrency support. Check out some of the <<features#,features>>.
+In short, I think Clojure occupies a unique niche as a functional Lisp for the JVM with strong concurrency support. Check out some of the <<features#,features>> or <<xref/../../guides/getting_started#,get started with Clojure>>.


### PR DESCRIPTION
There was some discussion about the Clojure website new user experience on Hacker News about 24 hours ago, and so I went to the "Getting Started" page to see what all the fuss was about. I ended up on the Overview page as the first link reading top-bottom left-right. The index page has a large green button labelled "Getting Started" that I skipped reading because it looked like a banner add and a prominent "Getting Started" button on the right hand side that looked like a "latest news" feed so I ignored it too. Some users, such as myself, are beyond hope.

Might someone please add a link to the Getting Started page at the end of the Rationale page? It seems like an extremely logical continuation.

- [ Yes] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [Yes ] Have you signed the Clojure Contributor Agreement?
- [Did My Best ] Have you verified your asciidoc markup is correct?
