### PR TITLE
Add introduction to Getting Started

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -9,13 +9,15 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 toc::[]
 
+== Strategy for Beginners
+
+Clojure is a hosted language; you will need the host platform, a library to translate Clojure code into a form the host understands, and a way of interacting with that library. The host platform for Clojure is the Java Virtual Machine (ClojureScript, a popular Clojure variant hosted in JavaScript, is not covered here) and it is assumed that you have already installed a recent version of Java. This guide will cover the remaining steps and after completing it you will have a viable environment for running Clojure code so you can experiment with the language.
+
+Check out <<learn/syntax#,Learn Clojure>>, <<xref/../../community/resources#,Resources>>, or <<xref/../../community/books#,Books>> for learning the syntax. You are encouraged to read up on the <<repl/introduction#,repl>> and <<deps_and_cli#,built in CLI tools>> for real-time ways of accessing the Clojure library, tools to run Clojure programs, and the official tools to handle dependency management. Clojure's built in tools are a recent development (introduced with Clojure 1.9.0), and as of the <<xref/../../news/2019/02/04/state-of-clojure-2019#,2019 State of Clojure survey>> they are still less popular than the community supported https://leiningen.org/[Leiningen] build tool for managing projects.
+
 Welcome to Clojure!
 
-Check out <<learn/syntax#,Learn Clojure>>, <<xref/../../community/resources#,Resources>>, or <<xref/../../community/books#,Books>> for learning the language!
-
 == Clojure installer and CLI tools
-
-Clojure provides <<deps_and_cli#,command line tools>> that can be used to start a Clojure repl, use Clojure and Java libraries, and start Clojure programs.
 
 === Installation on Mac via `brew`
 
@@ -71,10 +73,6 @@ Then start the REPL with the local jar:
 java -jar clojure.jar
 ----
 
-*Try Clojure online*
+== Try Clojure online
 
 https://repl.it/languages/clojure[repl.it] provides a browser-based Clojure repl for interactive exploration.
-
-*Build tools*
-
-Build tools provide a range of capabilities for building, running, and deploying Clojure libraries and applications. The two most popular Clojure build tools are https://leiningen.org/[Leiningen] and http://boot-clj.com/[Boot].


### PR DESCRIPTION
This is an attempt at fixing some of the issues identified in #356. New users of Clojure are funnelled to the "Getting Started" page which now provides a simple but comprehensive overview of what they need to do to enter the Clojure ecosystem. It prominently highlights the guides that must be read immediately to be able to sensibly interact with the online community (repl, deps_and_cli) and subtly links a reliable source for "what is everyone else doing" (2019 State of Clojure survey) that can be used to deduce what IDEs are appropriate.

I removed a reference to Boot as the 2019 State of Clojure survey suggests it is about as popular as writing custom shell scripts. It isn't obvious that it needs to be advertised to beginners.

- [Yes] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [Yes] Have you signed the Clojure Contributor Agreement?
- [Best Effort] Have you verified your asciidoc markup is correct?