### PR TITLE
Fix broken link

### DIFF
--- a/content/guides/weird_characters.adoc
+++ b/content/guides/weird_characters.adoc
@@ -638,7 +638,7 @@ See <<xref/../weird_characters#unquote_splicing,`~@`>> and <<xref/../weird_chara
 
 * http://www.braveclojure.com/writing-macros/[Clojure for the Brave and True - Writing Macros]
 * http://aphyr.com/posts/305-clojure-from-the-ground-up-macros[Clojure from the ground up: macros]
-* <<xref/../../macros#,Clojure Official Documentation>>
+* <<xref/../../reference/macros#,Clojure Official Documentation>>
 
 [[unqote]]
 == `~` - Unquote


### PR DESCRIPTION
URL for macro's doc has prefix missing. Think this used to be the URL a while ago, but it doesn't redirect.
