### PR TITLE
Update the var-quote forms

### DIFF
--- a/content/reference/vars.adoc
+++ b/content/reference/vars.adoc
@@ -21,7 +21,7 @@ The special form `def` creates (and <<vars#Interning,interns>>) a Var. If the Va
 [source,clojure]
 ----
 user=> (def x)
-.'user/x
+#'user/x
 user=> x
 #object[clojure.lang.Var$Unbound 0x14008db3 "Unbound: #'user/x"]
 ----
@@ -31,7 +31,7 @@ Supplying an initial value binds the root (even if it was already bound).
 [source,clojure]
 ----
 user=> (def x 1)
-.'user/x
+#'user/x
 
 user=> x
 1


### PR DESCRIPTION
Change the `.'user/x` forms to `#'user/x` forms.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [ ] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?

I have some trouble with signing the CA that all I can see is a gray screen with a few yellow empty boxes to fill in. I'm not sure what to do there. Any guidance would be helpful. Thank you.