### PR TITLE
Update URL scheme on Functions doc

### DIFF
--- a/content/guides/learn/functions.adoc
+++ b/content/guides/learn/functions.adoc
@@ -410,7 +410,7 @@ Hint: Using the http://docs.oracle.com/javase/8/docs/api/java/net/URL.html[java.
 (defn http-get [url]
   ___)
 
-(assert (.contains (http-get "http://www.w3.org") "html"))
+(assert (.contains (http-get "https://www.w3.org") "html"))
 ----
 In fact, the Clojure `slurp` function interprets its argument as a URL first before trying it as a file name. Write a simplified http-get:
 [source,clojure]


### PR DESCRIPTION
It turns out that when using http://www.w3.org/ the connection will
timeout, but when using https://www.w3.org/ results are as expected. I
can reproduce this using cURL, so it's not a Clojure thing, but still,
it could be frustrating to newbies to get an error while trying to
work on that exercise.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
