### PR TITLE
add missing argument

### DIFF
--- a/content/guides/core_async_go.adoc
+++ b/content/guides/core_async_go.adoc
@@ -45,7 +45,7 @@ to respect back-pressure.
     (fn [response]
       (put! out-c response (fn [_] (load-urls (next urls) out-c))))))
 
-(load-urls urls)
+(load-urls urls response-chan)
 ----
 
 In this example we have some nice clean interop code that allows us to


### PR DESCRIPTION
it seems that a 2-arity func is being invoked with 1 arg
I think a channel needs to passed in... or, according to `put!` docs, a "port" (whatever that is :))

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
