### PR TITLE
New Event - ClojureBridge London May 2019

### DIFF
--- a/content/events/2019/clojurebridge-london-may-2019.adoc
+++ b/content/events/2019/clojurebridge-london-may-2019.adoc
@@ -1,0 +1,56 @@
+= ClojureBridge London - Functional Works
+London Clojurians
+2019-05-11
+:jbake-type: event
+:jbake-edition: 2019
+:jbake-link: https://www.bridgetroll.org/events/471
+:jbake-location: London, United Kingdom
+:jbake-start: 2019-05-10
+:jbake-end: 2019-05-11
+
+https://clojurebridgelondon.github.io/[ClojureBridge London] is a fun, free and friendly workshop to support women(trans/cis) and non-binary people into software development. The workshop is suitable for people just starting to code, or people on their first language who are Clojure curious.
+
+=== Event overview
+Friday evening we have members of the community sharing their development experiences and demonstrating what you can do with Clojure. We also help you install Clojure development tools (optional).
+
+Saturday we coach you through a day of small practical exercises, building responsive websites or creating simple games. We aim for 1-2-1 coaching so we can support you each step of the way.
+
+=== Requirements
+Each participant requires their own laptop with either MacOSX, Linux or Windows operating system. We help you set up your laptop for Clojure during the Friday evening (optional if you are just starting to code).
+
+=== Why learn Clojure?
+Clojure is a small language with a simple design that can be used to build apps for the web, mobile apps, and even desktop apps. Clojure is a great choice for those new to programming, or existing developers who want to learn about functional programming and use it in the software industry.
+
+Clojure has a huge amount of libraries available to help you build a wide range of apps really quickly. You can use all the libraries from its host platforms, JavaScript/Node.js, Java or Microsoft .Net, too.
+
+For more information, please take a look at the https://clojurebridgelondon.github.io/[ClojureBridge London website]
+
+=== Our Sponsor
+Thank you to our sponsor https://functional.works-hub.com/[Functional Works] for providing the venue and all the food and refreshments for the event. We will aim to have 50% vegetarian food and around 10% of that will be vegan. We can always increase this based on you feedback.
+
+Functional Works are breaking down the barriers of hiring the right software engineers and providing a platform for managing the whole process (written in ClojureScript).
+
+image::https://www.works-hub.com/images/homepage/walkthrough02.svg
+
+=== Who is involved
+The event is free of charge and run by unpaid volunteers from the Clojure community. While the workshop is primarily for trans/cis women & non-binary attendees, our coaches and organisers are members of the local Clojure community of any gender or none. Everyone agrees to abide by the Bridge Foundry Code of Conduct.
+If anyone is interested in volunteering as a coach, take a look at the workshop content and if you understand the basic Clojure we cover then you can coach. Coach training is provided around a week before the event
+
+==== Volunteer Details
+Be sure to work through the exercises in the ClojureBridge London workshop before the coach training event.
+
+https://clojurebridgelondon.github.io/workshop/
+
+If you are interested in coaching students with some coding experience, also take a look at the projects in the workshop and have one of the recommended editors/IDE's installed.
+
+==== Student Details
+All students need to bring their own laptop and power adaptor
+
+If you want to build websites or games, then you will need to install development tools for Clojure. We can help with this on the Friday evening (or Saturday if required). Instructions are on our website https://clojurebridgelondon.github.io/workshop/development-tools/
+
+
+Thank you +
+London Clojurians +
+https://twitter.com/ldnclj
+
+image::https://raw.githubusercontent.com/jr0cket/london-clojurians-logo/master/london-clojurians-logo.png[London Clojurians logo]


### PR DESCRIPTION
Adding to the Clojure.org events section the next ClojureBridge London event to
be held in May 2019.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
