### PR TITLE
Extended the section for installation on Linux

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -35,15 +35,38 @@ brew upgrade clojure
 
 === Installation on Linux
 
-1. Ensure that the following dependencies are installed: bash, curl, rlwrap, and Java.
-2. Use the linux-install script to download and run the install, which will create /usr/local/bin/clj, /usr/local/bin/clojure, and /usr/local/lib/clojure:
+1. Ensure that the following dependencies are installed: `bash`, `curl`, `rlwrap`, and Java (Java JDK 11, 9 and 8 should be acceptable but you may want to [choose between different vendors](https://purelyfunctional.tv/guide/clojure-jvm/#which-jdk) ).
+2. Use the `linux-install` script to download and run the install, which will by default create executables `/usr/local/bin/clj`,   `/usr/local/bin/clojure` and directory `/usr/local/lib/clojure`:
 
 [source,shell]
 ----
-curl -O https://download.clojure.org/install/linux-install-1.10.0.442.sh
-chmod +x linux-install-1.10.0.442.sh
-sudo ./linux-install-1.10.0.442.sh
+VERSION=1.10.0.442
+curl -O https://download.clojure.org/install/linux-install-${VERSION}.sh
+chmod +x linux-install-${VERSION}.sh
+sudo ./linux-install-${VERSION}.sh
 ----
+
+If you want to put everything into a single location (for example `/opt/infrastructure/clojure`), use option `--prefix` instead:
+
+[source,shell]
+----
+VERSION=1.10.0.442
+curl -O https://download.clojure.org/install/linux-install-${VERSION}.sh
+chmod +x linux-install-${VERSION}.sh
+sudo ./linux-install-${VERSION}.sh --prefix /opt/infrastructure/clojure
+----
+
+If you select the "single location" approach you need to extend the MANPATH so that manual pages can be found.
+
+This is often done by extending `/etc/man_db.conf` adding a line like this:
+
+----
+MANPATH_MAP /opt/infrastructure/clojure/bin /opt/infrastructure/clojure/man
+----
+
+Note that the `VERSION` string is hardcoded in the `linux-install` script, which makes the script version-dependent!
+
+You can remove the `linux-install` script after installation.
 
 === Installation on Windows
 

--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -35,7 +35,7 @@ brew upgrade clojure
 
 === Installation on Linux
 
-1. Ensure that the following dependencies are installed: `bash`, `curl`, `rlwrap`, and Java (Java JDK 11, 9 and 8 should be acceptable but you may want to [choose between different vendors](https://purelyfunctional.tv/guide/clojure-jvm/#which-jdk) ).
+1. Ensure that the following dependencies are installed: `bash`, `curl`, `rlwrap`, and Java (Java JDK 11, 9 and 8 should be acceptable but you may want to https://purelyfunctional.tv/guide/clojure-jvm/#which-jdk[choose between different vendors] ).
 2. Use the `linux-install` script to download and run the install, which will by default create executables `/usr/local/bin/clj`,   `/usr/local/bin/clojure` and directory `/usr/local/lib/clojure`:
 
 [source,shell]
@@ -70,7 +70,8 @@ You can remove the `linux-install` script after installation.
 
 === Installation on Windows
 
-An early release version of clj on Windows is available at [clj on Windows](https://github.com/clojure/tools.deps.alpha/wiki/clj-on-Windows).
+An early release version of clj on Windows is available at https://github.com/clojure/tools.deps.alpha/wiki/clj-on-Windows[clj on Windows].
+
 Please provide feedback at https://dev.clojure.org/jira/browse/TDEPS.
 
 == Other ways to run Clojure


### PR DESCRIPTION
- Added a link to a (still-in-progress) page on purelyfunctional.tv regarding the JDK to use.
- The installation snippet uses a single VERSION string now. The installation script should probably be changed likewise as the VERSION is all over the place in there.
- Also added a comment on using the --prefix option
- However, the markdown links seem to be rendered incorrectly. That's probably because this is no longer markdown but Asciidoctor format, which has yet another different format for links? (Can I fix this later? There seems to be no way to re-edit the patch in flight)

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [ ] Have you verified your asciidoc markup is correct?
