### PR TITLE
Removing link to crossclj (site now shutdown)

### DIFF
--- a/content/api/api.adoc
+++ b/content/api/api.adoc
@@ -27,7 +27,6 @@ Documentation for Clojure <<xref/../../community/contrib_libs#,contrib libraries
 
 * https://www.conj.io/[Grimoire] - community combined cheatsheet + examples
 * https://clojuredocs.org[ClojureDocs] - community provided example repository
-* https://crossclj.info/[CrossClj] - library cross-reference
 * https://cljdoc.org/[cljdoc] - library documentation
 
 == Deprecated (pre Clojure 1.3)

--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -37,7 +37,6 @@ Community:
 * https://github.com/ClojureBridge/curriculum[ClojureBridge Curriculum]
 * https://www.conj.io/[Grimoire] - community combined cheatsheet + examples
 * https://clojuredocs.org[ClojureDocs] - community provided example repository
-* https://crossclj.info/[CrossClj] - library cross-reference
 * http://clojure-doc.org/[Clojure Documentation] - community-driven documentation site
 * http://clojurekoans.com/[Clojure Koans] (http://clojurescriptkoans.com/[online])
 * http://www.4clojure.com/[4clojure] - Clojure practice problems


### PR DESCRIPTION
..and the ads now on http://crossclj.info/ (without https) indicates the DNS service at namecheap has lapsed.

See also https://www.reddit.com/r/Clojure/comments/a99jwn/crossclj_is_shutting_down/ and https://github.com/fbellomi/crossclj where @fbellomi explains.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [ ] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
