### PR TITLE
Better markup for a few symbolic value occurrences

### DIFF
--- a/content/guides/learn/syntax.adoc
+++ b/content/guides/learn/syntax.adoc
@@ -29,7 +29,7 @@ The `;` creates a comment to the end of the line. Sometimes multiple semicolons 
 
 Integers are read as fixed precision 64-bit integers when they are in range and arbitrary precision otherwise. A trailing `N` can be used to force arbitrary precision. Clojure also supports the Java syntax for octal (prefix `0`), hexadecimal (prefix `0x`) and arbitrary radix (prefix with base then `r`) integers. Ratios are provided as their own type combining a numerator and denominator.
 
-Floating point values are read as double-precision 64-bit floats, or arbitrary precision with an `M` suffix. Exponential notation is also supported. The special symbolic values `##Inf`, `##-Inf`, and `##NaN` represent positive infinity, negative infinity, and "not a number" values respectively.
+Floating point values are read as double-precision 64-bit floats, or arbitrary precision with an `M` suffix. Exponential notation is also supported. The special symbolic values `pass:[##Inf]`, `pass:[##-Inf]`, and `pass:[##NaN]` represent positive infinity, negative infinity, and "not a number" values respectively.
 
 === Character types
 


### PR DESCRIPTION
- [y] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [y] Have you signed the Clojure Contributor Agreement?
- [y] Have you verified your asciidoc markup is correct?
