### PR TITLE
Update docs to also mention and link to Spec

### DIFF
--- a/content/guides/destructuring.adoc
+++ b/content/guides/destructuring.adoc
@@ -13,6 +13,8 @@ toc::[]
 
 Destructuring is a way to concisely bind names to the values inside a data structure. Destructuring allows us to write more concise and readable code.
 
+(See Also: <<xref/../../../about/spec#,Spec - Rationale and Overview>> - For a more modern take on specifying data structures, validating them, destructuring them, or even generating them.) 
+
 Consider the following example of extracting and naming values in a vector.
 
 [source,clojure]


### PR DESCRIPTION
The rationale is that web searching around, many folks land on this Destructuring guide and miss out on other forms of specifying data structures in Clojure.
Note to reviewers:  I am not sure if the link is the right format, so please advise or change appropriately before accepting PR.  I used exactly the same format that Rich uses in adoc.

- [X ] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X ] Have you signed the Clojure Contributor Agreement?
- [X ] Have you verified your asciidoc markup is correct?
