### PR TITLE
Conform a "let" word to asciidoc format

### DIFF
--- a/content/guides/learn/functions.adoc
+++ b/content/guides/learn/functions.adoc
@@ -213,7 +213,7 @@ Instead you can simply write:
 
 === `let`
 
-`let` binds symbols to values in a "lexical scope". A lexical scope creates a new context for names, nested inside the surrounding context. Names defined in a let take precedence over the names in the outer context.
+`let` binds symbols to values in a "lexical scope". A lexical scope creates a new context for names, nested inside the surrounding context. Names defined in a `let` take precedence over the names in the outer context.
 
 [source,clojure]
 ----


### PR DESCRIPTION
In the "Let" section, one of the "let" words isn't formatted correctly. My change is putting a "let" inside a pair of `.

- [y] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [y] Have you signed the Clojure Contributor Agreement?
- [y] Have you verified your asciidoc markup is correct?
