### PR TITLE
Notification of ClojureX 2019 cancellation

### DIFF
--- a/content/events/2019/clojurex.adoc
+++ b/content/events/2019/clojurex.adoc
@@ -1,4 +1,4 @@
-= ClojureX
+= ClojureX is cancelled
 London Clojurians
 2019-12-02
 :jbake-type: event
@@ -8,11 +8,17 @@ London Clojurians
 :jbake-start: 2019-12-02
 :jbake-end: 2019-12-03
 
-If you're looking for the best place to learn about Clojure, Functional Programming and network with like-minded people, then Clojure eXchange 2019 is the conference you simply can't miss. Meet with the world's leading experts on Clojure and learn the latest concepts and applications of Clojure to help your teams in their projects.
+Unfortunately the ClojureX conference scheduled for 2nd/3rd December 2019 has been cancelled.
 
-Its a two-day fun-packed conference that attracts speakers from around the world along with local developers in the community sharing their experiences.
+SkillsMatter, the company that owns, finances and runs the event has gone into financial administration and are effectively no longer a business.  SkillsMatter have previously run 10 successful Clojure conferences in London and the future of this conference is unknown.
 
-We hope you will https://skillsmatter.com/conferences/11936-clojure-exchange-2019[join us] and meet hundreds of people from the London Clojurians community and many other like-minded people from around the world.
+London Clojurians appologies to all speakers who make travel plans or attendees who purchased tickets/travel.  We do not know if any of this is recoverable.
+
+London Clojurians will share any further developments on this matter that are relevant to the Clojurian community as soon as we can.
+
+Please use the #clojurex channel on the Clojurians Slack channel if you have questions and we will try our best to advise.
+
+Again, our deepest appologies to all involved in this event.
 
 Thank you +
 London Clojurians +


### PR DESCRIPTION
Unfortunately the company that runs ClojureX conference in London is in financial administration.

- [ x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [ x] Have you signed the Clojure Contributor Agreement?
- [ x] Have you verified your asciidoc markup is correct?
