### PR TITLE
explain language name choice

### DIFF
--- a/content/about/rationale.adoc
+++ b/content/about/rationale.adoc
@@ -19,6 +19,10 @@ Clojure has a distinctive approach to <<state#,state and identity>>.
 
 == Why Clojure?
 
+Clojure is pronounced exactly like closure, it's actually a pun.
+
+I wanted an unique name involving c (c#), l (lisp) and j (java).
+
 Why did I write yet another programming language? Basically because I wanted:
 
 * A Lisp


### PR DESCRIPTION
In response to the following [issue](https://github.com/clojure/clojure-site/issues/402).

I found that it would be interesting to explain, in a few words, why it is called Clojure on the Rationale page.

Rich explained it [here](https://groups.google.com/d/msg/clojure/4uDxeOS8pwY/UHiYp7p1a3YJ).