### PR TITLE
Remove Altometrics from companies list

### DIFF
--- a/content/community/companies.adoc
+++ b/content/community/companies.adoc
@@ -24,7 +24,6 @@ Also, check out the <<success_stories#,Clojure Success Stories>> and <<community
 * https://www.akamai.com/[Akamai,opts=nofollow]
 * https://akvo.org[Akvo Foundation,opts=nofollow]
 * http://akvo.org/[akvo.org,opts=nofollow]
-* http://altometrics.com/[Altometrics,opts=nofollow]
 * http://www.amazon.com[Amazon,opts=nofollow]
 * https://amperity.com/[Amperity,opts=nofollow]
 * https://www.animalia.no/[Animalia,opts=nofollow]


### PR DESCRIPTION
Altometrics is now defunct. I should know; I was a co-founder.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?