### PR TITLE
Make more explicit that Clojure 1.10 needs spec deps at runtime

### DIFF
--- a/content/community/downloads.adoc
+++ b/content/community/downloads.adoc
@@ -7,6 +7,8 @@ Rich Hickey
 
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
+**Note: the information on this page is useful to more experienced developers. If you are new to the language please see the <<xref/../../guides/getting_started#,Getting Started>> guide instead.**
+
 == Stable Release: 1.10.1 (June 6, 2019)
 
 * For installation, see: <<xref/../../guides/getting_started#,Getting Started>>
@@ -20,6 +22,14 @@ Clojure depends on Java and all Clojure code is compiled to Java 8 compatible by
 * Minimum runtime dependency: Java 8
 * Supported: LTS (long term support) releases, currently Java 8 and Java 11
 * Others: likely work, but not officially supported
+* Clojure depends at runtime on the Clojure Spec packages listed below
+
+=== Spec Dependencies
+
+Clojure 1.10 itself depends on the following versions the Clojure Spec packages to run
+
+ * spec.alpha - 0.2.176
+ * core.specs.alpha - 0.2.44
 
 == Development Release: 1.10.2-alpha1 (March 5, 2020)
 


### PR DESCRIPTION
For someone completely new to Clojure, it's reasonable that most people will click on the large Get Started button, but a few people will still click on Releases and then the second link on the Releases page takes you to straight to the Maven repo, which is relevant for developers with experience with Maven or aware of the spec deps in Clojure 1.10.

Since there's still old pages and blogs that mention you can download a single Clojure jar ("it's just another Jar"), this hurts their fix experience into the language, because java -jar clojure-1.10.0.jar throws an Exception they cannot decipher.

All that the Releases page needs is a banner that warns people that if you are new to the language, go to the Getting Started page. I've also added a small entry to make more explicit that the Clojure jar alone is not enough to run Clojure anymore (maybe it can be improved to read "since Clojure 1.9").

I found this case when answering a question on Stack Overflow ( https://stackoverflow.com/q/60625209/483566 ) but it seems it's happened before ( https://stackoverflow.com/q/49476215/483566 )

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
