### PR TITLE
Clarify next step after installation

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -23,6 +23,8 @@ The Clojure tools require that either the `java` command is on the path or that 
 
 Clojure provides <<deps_and_cli#,command line tools>> that can be used to start a Clojure repl, use Clojure and Java libraries, and start Clojure programs. See the https://github.com/clojure/brew-install/blob/1.10.1/CHANGELOG.md[changelog] for version information.
 
+After following these installation instructions, you should be able to use the `clj` or `clojure` command to start a Clojure repl.
+
 === Installation on Mac via https://brew.sh[Homebrew]
 
 Install the command line tools with `brew` from the clojure/tools tap:


### PR DESCRIPTION
The installation instructions do not indicate what the next step should be: indicate that `clj` and/or `clojure` commands should be available.

- [ ] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [ ] Have you signed the Clojure Contributor Agreement?
- [ ] Have you verified your asciidoc markup is correct?
