### PR TITLE
Fix jbake install instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ The site is built using http://jbake.org/[JBake].
 
 To https://jbake.org/docs/2.6.3/#installation[install] JBake 2.6.3:
 
-. `curl -O https://dl.bintray.com/jbake/binary/jbake-2.6.3-bin.zip` (or download this file with your browser)
+. `curl -L -O https://dl.bintray.com/jbake/binary/jbake-2.6.3-bin.zip` (or download this file with your browser)
 . `unzip -o jbake-2.6.3-bin.zip`
 . Add jbake-2.6.3-bin/bin to your system PATH
 


### PR DESCRIPTION
The jbake install link redirects, so passing -L is necessary in order
for curl to follow the redirect.


- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?