### PR TITLE
Update recommendations for VS Code and Atom

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -100,8 +100,8 @@ Community volunteers maintain <<xref/../../guides/getting_started#,Getting Start
 * https://sekao.net/nightcode/[Nightcode]
 * http://www.lighttable.com/[Light Table]
 * http://www.sublimetext.com/[Sublime Text] with https://github.com/wuub/SublimeREPL[SublimeREPL]
-* https://atom.io[Atom] with https://atom.io/packages/nrepl[nrepl]
-* https://code.visualstudio.com[Visual Studio Code] with https://github.com/avli/clojureVSCode[clojureVSCode]
+* https://atom.io[Atom] with https://github.com/mauricioszabo/atom-chlorine[Chlorine]
+* https://code.visualstudio.com[Visual Studio Code] with https://github.com/BetterThanTomorrow/calva[Calva]
 * http://doc.ccw-ide.org/[Eclipse Counterclockwise] (inactive)
 
 == Conferences


### PR DESCRIPTION
I've updated the recommended plugins/extensions for Atom, to Chlorine, and for VS Code, to Calva. In the latter case I am quite biased, but as [this question](https://github.com/avli/clojureVSCode/issues/113) suggests, `clojureVSCode` does not fully qualify the expectations for an editor integration as they are expressed on this page. Calva does, however.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
