### PR TITLE
Fix link to 404 at enhancing_your_repl_workflow

### DIFF
--- a/content/guides/repl/enhancing_your_repl_workflow.adoc
+++ b/content/guides/repl/enhancing_your_repl_workflow.adoc
@@ -224,7 +224,7 @@ lightweight syntax.
 
 ==== Going further: tracing libraries
 
-_Tracing_ libraries such as **https://github.com/clojure/tools.trace[tools.trace]** and **http://clojure-emacs.github.io/sayid/[Sayid]**
+_Tracing_ libraries such as **https://github.com/clojure/tools.trace[tools.trace]** and **https://github.com/clojure-emacs/sayid[Sayid]**
 can help you instrument larger portions of your code, for example by automatically printing all the function calls in a
 given namespace, or all intermediary values in a given expression.
 


### PR DESCRIPTION
page http://clojure-emacs.github.io/sayid/ is 404 now, replace to https://github.com/clojure-emacs/sayid

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
