### PR TITLE
'executables' spelling correction

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -46,7 +46,7 @@ brew upgrade clojure/tools/clojure
 To install with the Linux script installer:
 
 1. Ensure that the following dependencies are installed: `bash`, `curl`, `rlwrap`, and `Java`.
-2. Use the `linux-install` script to download and run the install, which will create the executales `/usr/local/bin/clj`, `/usr/local/bin/clojure`, and the directory `/usr/local/lib/clojure`:
+2. Use the `linux-install` script to download and run the install, which will create the executables `/usr/local/bin/clj`, `/usr/local/bin/clojure`, and the directory `/usr/local/lib/clojure`:
 
 [source,shell]
 ----


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?

a small change correcting a typo. 
"executales" -> "executables"
