### PR TITLE
Fixes small typo in guides/repl/basic_usage.

### DIFF
--- a/content/guides/repl/basic_usage.adoc
+++ b/content/guides/repl/basic_usage.adoc
@@ -110,7 +110,7 @@ user=> (clojure.string/upper-case "clojure")
 "CLOJURE"
 ----
 
-`https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/require[require]` also lets use
+`https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/require[require]` also lets us
  define an _alias_ for the `clojure.string` namespace, by adding an `:as` clause. This enables us to
  refer to names defined in the `clojure.string` namespace more concisely:
 


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
