### PR TITLE
Deps: mention where git deps are stored

### DIFF
--- a/content/reference/deps_and_cli.adoc
+++ b/content/reference/deps_and_cli.adoc
@@ -679,6 +679,8 @@ For more information on creating keys and using the ssh-agent to manage your ssh
 
 _Note: user/password authentication is not supported for any protocol._
 
+The repositories are cloned into `~/.gitlibs`.
+
 == Installers
 
 For tools installation, see the instructions in the <<xref/../../guides/getting_started#,Getting Started>> guide.


### PR DESCRIPTION
...so that users know where to look if they run into problems (such as "Destination path [..] already exists")

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
