### PR TITLE
Point "repo changelog" link at 1.10.2 branch

### DIFF
--- a/content/releases/tools.adoc
+++ b/content/releases/tools.adoc
@@ -20,7 +20,7 @@ For more information see the following docs:
 
 == Releases
 
-Recent official releases are described here. Prereleases and older versions can be found in the https://github.com/clojure/brew-install/blob/1.10.1/CHANGELOG.md[repo changelog].
+Recent official releases are described here. Prereleases and older versions can be found in the https://github.com/clojure/brew-install/blob/1.10.2/CHANGELOG.md[repo changelog].
 
 === 1.10.2.796 (Feb 23, 2021) [[v1.10.2.796]]
 


### PR DESCRIPTION
This branch has the same old releases, but also the newer 1.10.2.x releases.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
