### PR TITLE
Update Clojurians Slack link

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -11,7 +11,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 * https://ask.clojure.org[Q&A Forum] (official)
 * https://groups.google.com/group/clojure[Clojure Google Group] (official)
-* http://clojurians.net[Clojurians Slack Chat]
+* https://join.slack.com/t/clojurians/shared_invite/zt-lsr4rn2f-jealnYXLHVZ61V2vdi15QQ[Clojurians Slack Chat]
 * https://clojurians.zulipchat.com[Clojurians Zulip Chat]
 * https://clojureverse.org[Clojureverse]
 * https://clojure.org/community/user_groups[Clojure User Groups]


### PR DESCRIPTION
Right now, the link is to clojurians.net which used to be the "inviter app" but was changed to just redirect to a join-Slack invitation link (because Slack changed how invitations worked). Unfortunately, that link has expired and the Clojurians Admin team do not have access to clojurians.net to change the link to a new one.

So I'm proposing changing the link on clojure.org to directly be a new invitation link -- it should not expire until 2,000 people have used it (in theory) -- and once we get control of clojurians.net again, I'll submit a PR to change this page back to clojurians.net. I'll also keep an eye on signups and if it looks like this new link will "run out", I'll get a new one created and submit another PR.

Sorry for the churn but we're out of options for the time being since Slack has no self-signup option.

- [ ] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [ ] Have you signed the Clojure Contributor Agreement?
- [ ] Have you verified your asciidoc markup is correct?
