### PR TITLE
Clojurians Slack Chat link -> clojurians.net

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -11,7 +11,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 * https://ask.clojure.org[Q&A Forum] (official)
 * https://groups.google.com/group/clojure[Clojure Google Group] (official)
-* https://join.slack.com/t/clojurians/shared_invite/zt-lsr4rn2f-jealnYXLHVZ61V2vdi15QQ[Clojurians Slack Chat]
+* http://clojurians.net[Clojurians Slack Chat]
 * https://clojurians.zulipchat.com[Clojurians Zulip Chat]
 * https://clojureverse.org[Clojureverse]
 * https://clojure.org/community/user_groups[Clojure User Groups]


### PR DESCRIPTION
The Admin team now own the domain and have full access to it, and have it redirecting to a new Slack signup link.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
