### PR TITLE
Update Clojure Korea Link

### DIFF
--- a/content/community/user_groups.adoc
+++ b/content/community/user_groups.adoc
@@ -139,7 +139,7 @@ Riviera Scala, (Twitter: https://twitter.com/riviera_func[@riviera_func])
 ** http://clojure-china.org/[Clojure China] and http://weibo.com/clojurechina
 ** https://www.meetup.com/Clojure-Israel/[Clojure Israel]
 ** https://groups.google.com/forum/#!forum/clojuresg[Singapore Clojure User Group]
-** http://clojure.kr[Clojure Korea]
+** https://www.facebook.com/groups/defnclojure[Clojure Korea]
 ** http://clojure.tw[Clojure Taiwan]
 
 [[australianz]]


### PR DESCRIPTION
Change Clojure Korea link in User Groups.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
