### PR TITLE
Fix typo: change 'and' to 'of'

### DIFF
--- a/content/news/2021/03/18/apis-serving-people-and-programs.adoc
+++ b/content/news/2021/03/18/apis-serving-people-and-programs.adoc
@@ -7,7 +7,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 To date, Clojure’s support for keyword arguments forces programmers to choose between creating APIs that better support people (accepting keyword args) or APIs that better support programs (by taking a map of those args).
 
-Introduced in Clojure 1.11, a function specified to take keyword arguments may be passed a single map instead of or in addition to (and following) the key/value pairs. When a lone map is passed, it is used outright for destructuring, else a trailing map is added to the map built from the preceding key/values via `conj`. For example, a function that takes a sequence and optional keyword arguments and returns a vector containing the values is defined as:
+Introduced in Clojure 1.11, a function specified to take keyword arguments may be passed a single map instead of or in addition to (and following) the key/value pairs. When a lone map is passed, it is used outright for destructuring, else a trailing map is added to the map built from the preceding key/values via `conj`. For example, a function that takes a sequence of optional keyword arguments and returns a vector containing the values is defined as:
 
 [source,clojure]
 ----


### PR DESCRIPTION
A couple of people have been confused by the current wording on Slack: I believe the intent was to say that `destr` "takes a sequence _of_ optional keyword arguments" (not _and_).

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
