### PR TITLE
Add Zimpler to Clojure community companies

### DIFF
--- a/content/community/companies.adoc
+++ b/content/community/companies.adoc
@@ -501,4 +501,5 @@ Also, check out the <<success_stories#,Clojure Success Stories>> and <<community
 * Zalando
 * Zendesk
 * Zen Finance
+* Zimpler
 * Zoona


### PR DESCRIPTION
Swedish startup Zimpler is using Clojure in production for over 7 years now and should be on this list.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
