### PR TITLE
IRC channel moved from Freenode to Libera

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -16,7 +16,7 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 * https://clojureverse.org[Clojureverse]
 * https://clojure.org/community/user_groups[Clojure User Groups]
 * http://planet.clojure.in/[Planet Clojure] blog aggregator
-* #clojure IRC channel on https://freenode.net[freenode.net]
+* #clojure IRC channel on https://libera.chat[Libera.Chat]
 * https://discord.gg/discljord[Discljord Clojure Discord Server]
 * https://discord.gg/MsejPv9JNG[Clojurians Discord Server]
 


### PR DESCRIPTION
Upon joining #clojure on Freenode, ChanServ sends the following message:

> @ChanServ: [#clojure] This channel is moving to #clojure on irc.libera.chat

Seems proper to point the website to Libera channel as well.

Background on the move: 

- https://mastodon.sdf.org/@kline/106299403921451814
- https://lwn.net/Articles/856543/

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
