### PR TITLE
Fix ref to non-existent partition transducer

### DIFF
--- a/content/reference/transducers.adoc
+++ b/content/reference/transducers.adoc
@@ -155,7 +155,7 @@ A process that uses transducers must check for and stop when the step function r
 
 === Transducers with reduction state
 
-Some transducers (such as *take*, *partition*, etc) require state during the reduction process. This state is created each time the transducible process applies the transducer. For example, consider the dedupe transducer that collapses a series of duplicate values into a single value. This transducer must remember the previous value to determine whether the current value should be passed on:
+Some transducers (such as *take*, *partition-all*, etc) require state during the reduction process. This state is created each time the transducible process applies the transducer. For example, consider the dedupe transducer that collapses a series of duplicate values into a single value. This transducer must remember the previous value to determine whether the current value should be passed on:
 [source,clojure]
 ----
 (defn dedupe []


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?

Since `partition` doesn't have a transducer arity, I assume a better example is `partition-all`.