### PR TITLE
Fix gitlab lib to url conventions

### DIFF
--- a/content/reference/deps_and_cli.adoc
+++ b/content/reference/deps_and_cli.adoc
@@ -764,8 +764,8 @@ Lib to url convention:
 |Lib format | Inferred `:git/url`
 |io.github.ORG/PROJECT | `"https://github.com/ORG/PROJECT.git"`
 |com.github.ORG/PROJECT | `"https://github.com/ORG/PROJECT.git"`
-|io.github.ORG/PROJECT | `"https://gitlab.com/ORG/PROJECT.git"`
-|com.github.ORG/PROJECT | `"https://gitlab.com/ORG/PROJECT.git"`
+|io.gitlab.ORG/PROJECT | `"https://gitlab.com/ORG/PROJECT.git"`
+|com.gitlab.ORG/PROJECT | `"https://gitlab.com/ORG/PROJECT.git"`
 |io.bitbucket.ORG/PROJECT | `"https://bitbucket.org/ORG/PROJECT.git"`
 |org.bitbucket.ORG/PROJECT | `"https://bitbucket.org/ORG/PROJECT.git"`
 |io.beanstalkapp.ORG/PROJECT | `"https://ORG.git.beanstalkapp.com/PROJECT.git"`


### PR DESCRIPTION
Based on https://github.com/clojure/tools.deps.alpha/blob/655ea0a037f041e365cc56db0dc8181268c29998/src/main/clojure/clojure/tools/deps/alpha/extensions/git.clj#L19

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
