### PR TITLE
Add in re:Clojure 2021

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -43,7 +43,6 @@ Community:
 * https://clojuredocs.org[ClojureDocs] - community provided example repository
 * http://clojure-doc.org/[Clojure Documentation] - community-driven documentation site
 * http://clojurekoans.com/[Clojure Koans] (http://clojurescriptkoans.com/[online])
-* http://www.4clojure.com/[4clojure] - Clojure practice problems
 * http://exercism.io/[exercism.io] - crowd-source code reviews (supports Clojure)
 * https://guide.clojure.style/[Clojure Style Guide]
 * https://www.maria.cloud/[Maria] - a coding environment for beginners
@@ -107,7 +106,7 @@ Video training (commercial):
 * http://clojure-conj.org/[Clojure/conj] (usually in November)
 * http://www.clojurebridge.org/[ClojureBridge] - beginner workshops for women
 * https://clojutre.org[ClojuTRE] - A Clojure conference in Tampere/Helsinki, Finland
-* https://skillsmatter.com/conferences/10459-clojure-exchange-2018[Clojure eXchange] - A Clojure conference in London, UK
+* https://reclojure.org[re:Clojure] - A yearly community-driven Clojure conference, hosted online and with a worldwide attendance
 * https://clojured.de/[clojureD] - A Clojure conference in Berlin, Germany
 * https://heartofclojure.eu/[Heart of Clojure] - A Clojure conference in Leuven, Belgium
 * https://clojuredays.org/[Dutch Clojure Days] - A Clojure conference in Amsterdam, the Netherlands

--- a/content/events/2021/reclojure.adoc
+++ b/content/events/2021/reclojure.adoc
@@ -1,0 +1,25 @@
+= re:Clojure
+London Clojurians
+2021-12-03
+:jbake-type: event
+:jbake-edition: 2021
+:jbake-link: https://reclojure.org
+:jbake-location: London, United Kingdom
+:jbake-start: 2021-12-03
+:jbake-end: 2021-12-04
+
+re:Clojure is a community-driven effort to bring together
+knowledgeable speakers to present new and exciting topics on all
+things Clojure and ClojureScript.
+
+This year, like last year (during these COVID times), the conference
+will be held online, on the 3rd and 4th of December 2021. You are
+cordially invited to come along, listen, participate and perhaps learn
+one or two new things along the way.
+
+For further details, including the speakers/schedule/instructions and
+how to attend, please visit https://reclojure.org[re:Clojure]. You can
+also pop along to our https://discord.com/invite/m4DaGW6N[Discord
+server] to speak to any of the organisers and fellow Clojurians.
+
+We look forward to seeing you there!


### PR DESCRIPTION
Also remove skillsmatter, as this conference no longer exists.

Remove also 4clojure.com, as this service is deprecated (and the website
gives a security warning).

-=david=-

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
