### PR TITLE
:require class -> :require clause

### DIFF
--- a/content/guides/learn/namespaces.adoc
+++ b/content/guides/learn/namespaces.adoc
@@ -65,7 +65,7 @@ The `clojure.core` referral is done by the `ns` macro. (There are ways to suppre
 
 === require
 
-The `:require` class corresponds to the `require` function which specifies one or more namespaces to load that this namespace depends on. For each namespace, `require` can do several things:
+The `:require` clause corresponds to the `require` function which specifies one or more namespaces to load that this namespace depends on. For each namespace, `require` can do several things:
 
 * Load (or reload) the namespace
 * Optionally assign an _alias_ that can be used to refer to vars from the loaded namespace only in the scope of this namespace


### PR DESCRIPTION
I was puzzled that `:require` was referred to as a "class", then saw that in the following section, `:import` is called a "clause".

> the ns macro has an :import clause

I believe that the author meant to say "clause" above as well. 

Thanks!

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
