### PR TITLE
Remove wikispaces from the tools section

### DIFF
--- a/content/community/start_group.adoc
+++ b/content/community/start_group.adoc
@@ -27,7 +27,6 @@ A user group needs the following elements:
 * Meetup - http://meetup.com/[http://meetup.com] - meeting discovery, calendar, user network (75% discount available)
 * Google Groups - http://groups.google.com[http://groups.google.com] - free mailing list
 * Yahoo Groups - http://groups.yahoo.com[http://groups.yahoo.com] - free mailing list
-* Wikispaces - http://wikispaces.com/[http://wikispaces.com] - free wiki
 * YouTube - http://youtube.com[http://youtube.com] - video hosting
 
 == Common problems


### PR DESCRIPTION
Wikispaces is not functioning anymore since 2018.

https://helpiewp.com/wikispaces/

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
