### PR TITLE
Getting started: add OpenJDK install suggestions for Mac OS X, Ubuntu Linux and Windows

### DIFF
--- a/content/guides/getting_started.adoc
+++ b/content/guides/getting_started.adoc
@@ -19,6 +19,28 @@ Clojure requires Java. Clojure officially supports Java LTS releases (currently 
 
 The Clojure tools require that either the `java` command is on the path or that the `JAVA_HOME` environment variable is set.
 
+=== Java: installation on Mac via https://brew.sh[Homebrew]
+
+OpenJDK is available to install via the `brew` command:
+
+[source,shell]
+----
+brew install openjdk
+----
+
+=== Java installation on Linux
+
+For Ubuntu users, OpenJDK is available to install via the `apt` command:
+
+[source,shell]
+----
+sudo apt install default-jdk
+----
+
+=== Java: installation on Windows using the https://docs.microsoft.com/en-us/java/openjdk/overview[Microsoft build of OpenJDK]
+
+OpenJDK for Windows is available as an `MSI` installer at the https://docs.microsoft.com/en-us/java/openjdk/download[Microsoft download page for OpenJDK].
+
 == Clojure installer and CLI tools
 
 Clojure provides <<deps_and_cli#,command line tools>> that can be used to start a Clojure repl, use Clojure and Java libraries, and start Clojure programs. 


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?

I was about to install Clojure on a new Mac OS X computer, and got a bit confused on how (and from where) to install Java. Then I found out that OpenJDK is on `Homebrew` and installed it from there. I also found it a bit unclear on how to do the same thing on Windows, and tried out the Microsoft MSI package that went well and without issues.

That is why I think it might be a good idea to clarify this step at the `Getting Started` page.