### PR TITLE
Fix bugs in `gen/fmap` documentation

### DIFF
--- a/content/guides/spec.adoc
+++ b/content/guides/spec.adoc
@@ -1116,7 +1116,7 @@ In this case we want our keyword to have open names but fixed namespaces. There 
 
 [source,clojure]
 ----
-(def kw-gen-2 (gen/fmap #(keyword "my.domain" %) (gen/string-alphanumeric)))
+(def kw-gen-2 (gen/fmap #(keyword "my.domain" %) gen/string-alphanumeric))
 (gen/sample kw-gen-2 5)
 ;;=> (:my.domain/ :my.domain/ :my.domain/1 :my.domain/1O :my.domain/l9p2)
 ----
@@ -1129,7 +1129,7 @@ However, we can spot a problem in the example above - generators are often desig
 ----
 (def kw-gen-3 (gen/fmap #(keyword "my.domain" %)
                (gen/such-that #(not= % "")
-                 (gen/string-alphanumeric))))
+                 gen/string-alphanumeric)))
 (gen/sample kw-gen-3 5)
 ;;=> (:my.domain/O :my.domain/b :my.domain/ZH :my.domain/31 :my.domain/U)
 ----
@@ -1141,7 +1141,7 @@ Returning to our "hello" example, we now have the tools to make that generator:
 (s/def :ex/hello
   (s/with-gen #(clojure.string/includes? % "hello")
     #(gen/fmap (fn [[s1 s2]] (str s1 "hello" s2))
-      (gen/tuple (gen/string-alphanumeric) (gen/string-alphanumeric)))))
+      (gen/tuple gen/string-alphanumeric gen/string-alphanumeric))))
 (gen/sample (s/gen :ex/hello))
 ;;=> ("hello" "ehello3" "eShelloO1" "vhello31p" "hello" "1Xhellow" "S5bhello" "aRejhellorAJ7Yj" "3hellowPMDOgv7" "UhelloIx9E")
 ----


### PR DESCRIPTION
The documentation for `clojure.test.check.generators/fmap` will throw an error when run. 

`gen/fmap` has a signature of `[f gen]`. The generators in spec.adoc are being cast to function names in the example calls to `gen/fmap` (e.g. `(gen/string-alphanumeric)`). They should be evaluated as a generator (e.g. `gen/string-alphanumeric`).

The current evaluation result is an *Execution error: class clojure.test.check.generators.Generator cannot be cast to class clojure.lang.IFn*. The proposed changes allow for proper execution.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
