### PR TITLE
Adjust link to Obsidian Wielder

### DIFF
--- a/content/news/2022/06/24/deref.adoc
+++ b/content/news/2022/06/24/deref.adoc
@@ -49,7 +49,7 @@ New releases and tools this week:
 * https://github.com/athos/Postmortem[Postmortem] 0.5.1 - A tiny data-oriented debugging tool for Clojure(Script), powered by transducers
 * https://github.com/cognitect/transit-cljs[transit-cljs]  - Transit for ClojureScript
 * https://git.sr.ht/~jomco/proof-specs[proof-specs] 0.1.3 - Automates testing clojure.spec data generators
-* https://wielder.victor.earth/Tutorials/01-Introduction[https://wielder.victor.earth/Tutorials/01-Introduction]  - Wielder enables you to write Clojure code directly in Obsidian
+* https://wielder.victor.earth[https://wielder.victor.earth]  - Wielder enables you to write Clojure code directly in Obsidian
 * https://clojure-lsp.io/[clojure-lsp] 2022.06.22-14.09.50 - A Language Server for Clojure(script)
 * https://github.com/cljfx/flowless[flowless]  - Cljfx wrapper of Flowless
 * https://github.com/clj-kondo/clj-kondo[clj-kondo] 2022.06.22 - A linter for Clojure code that sparks joy


### PR DESCRIPTION
Made the link go to the main page as it has a better overview + demonstration video

Also makes the URL a bit prettier on the deployed website :)

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
