### PR TITLE
Add newline to fix formatting in deps_and_cli.adoc

### DIFF
--- a/content/reference/deps_and_cli.adoc
+++ b/content/reference/deps_and_cli.adoc
@@ -819,6 +819,7 @@ The `git` procurer supports direct use of source-based libs hosted in Git reposi
 To specify a git lib as a dependency, two pieces of information must be known - the Git repo url and a specific sha. Using movable references like branch names is not supported.
 
 Git coordinates have the following attributes:
+
 * `:git/url` - optional, Git url (may be inferred from lib name, see below)
 * `:git/sha` - required, either a full 40-char sha or a sha prefix can be provided in combination with a tag (`:sha` is also accepted for backwards compatibility)
 * `:git/tag` - optional, git tag name (may be used only in combination with a `:git/sha`)


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?

Fixes the following formatting issue:

<img width="981" alt="image" src="https://user-images.githubusercontent.com/11401/183249881-dd4bae9f-5d5f-423c-be37-8bcd148d56c3.png">
