### PR TITLE
Update macros.adoc: fix typo in example output

### DIFF
--- a/content/reference/macros.adoc
+++ b/content/reference/macros.adoc
@@ -30,7 +30,7 @@ Other macros re-arrange forms in useful ways, like the `pass:[->]` macro, which 
 user=> (-> {} (assoc :a 1) (assoc :b 2))
 {:b 2, :a 1}
 user=> (macroexpand '(-> {} (assoc :a 1) (assoc :b 2)))
-(assoc (clojure.core/-> {} (assoc :a 1)) :b 2)
+(assoc (assoc {} :a 1) :b 2)
 ----
 
 == Special variables


### PR DESCRIPTION
`(macroexpand '(-> {} (assoc :a 1) (assoc :b 2)))` actually produces `(assoc (assoc {} :a 1) :b 2)` (which is also what makes sense from the text description).

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
