### PR TITLE
Remove the inactive Discord server

### DIFF
--- a/content/community/resources.adoc
+++ b/content/community/resources.adoc
@@ -18,7 +18,6 @@ ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 * http://planet.clojure.in/[Planet Clojure] blog aggregator
 * #clojure IRC channel on https://libera.chat[Libera.Chat]
 * https://discord.gg/discljord[Discljord Clojure Discord Server]
-* https://discord.gg/MsejPv9JNG[Clojurians Discord Server]
 * https://twitter.com/i/communities/1494013093059432451[Twitter Community]
 * https://clj.social[Clojure Community on Fediverse]
 


### PR DESCRIPTION
Discljord is still active but the other Discord community has had no moderators and almost no activity for a year now.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
