### PR TITLE
Make the binding example clearer

### DIFF
--- a/content/reference/vars.adoc
+++ b/content/reference/vars.adoc
@@ -41,19 +41,20 @@ By default Vars are static, but Vars can be marked as dynamic to allow per-threa
 
 [source,clojure]
 ----
-user=> (def ^:dynamic x 1)
-user=> (def ^:dynamic y 1)
-user=> (defn sum [] (+ x y)
-#'user/sum
-user=> (sum)
-2
+user=> (def ^:dynamic *now* (java.time.LocalDateTime/now))
+#'user/*now*
+user=> *now*
+#object[java.time.LocalDateTime 0x74075134 "2022-12-02T12:19:45.396452"]
 
-user=> (binding [x 2 y 3]
-         (sum))
-5
+user=> (defn next-week [] (.plusDays *now* 7))
+#'user/next-week
+user=> (next-week)
+#object[java.time.LocalDateTime 0x6d9fb2d1 "2022-12-09T12:19:45.396452"]
 
-user=> (sum)
-2
+
+user=> (binding [*now* (java.time.LocalDateTime/parse "2023-01-01T00:00:00")]
+         (next-week))
+#object[java.time.LocalDateTime 0xf2ce6b "2023-01-08T00:00"]
 ----
 
 Bindings created with `binding` cannot be seen by any other thread. Likewise, bindings created with `binding` can be assigned to, which provides a means for a nested context to communicate with code before it is placed on the call stack. This capability is opt-in only by setting a metadata tag: `^:dynamic` to true as in the code block above. There are scenarios that one might wish to redefine static Vars within a context and Clojure (since version 1.3) provides the functions https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/with-redefs[with-redefs] and https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/with-redefs-fn[with-redefs-fn] for such purposes.

--- a/content/reference/vars.adoc
+++ b/content/reference/vars.adoc
@@ -43,14 +43,16 @@ By default Vars are static, but Vars can be marked as dynamic to allow per-threa
 ----
 user=> (def ^:dynamic x 1)
 user=> (def ^:dynamic y 1)
-user=> (+ x y)
+user=> (defn sum [] (+ x y)
+#'user/sum
+user=> (sum)
 2
 
 user=> (binding [x 2 y 3]
-         (+ x y))
+         (sum))
 5
 
-user=> (+ x y)
+user=> (sum)
 2
 ----
 

--- a/content/reference/vars.adoc
+++ b/content/reference/vars.adoc
@@ -42,12 +42,10 @@ By default Vars are static, but Vars can be marked as dynamic to allow per-threa
 [source,clojure]
 ----
 user=> (def ^:dynamic *now* (java.time.LocalDateTime/now))
-#'user/*now*
 user=> *now*
 #object[java.time.LocalDateTime 0x74075134 "2022-12-02T12:19:45.396452"]
 
 user=> (defn next-week [] (.plusDays *now* 7))
-#'user/next-week
 user=> (next-week)
 #object[java.time.LocalDateTime 0x6d9fb2d1 "2022-12-09T12:19:45.396452"]
 


### PR DESCRIPTION
I believe that for beginners who still don't understand how Vars work, having a more indirect example like the one I proposed makes the `binding` explanation much clearer.