### PR TITLE
Fix broken link in ClojureCLR page

### DIFF
--- a/content/about/clojureclr.adoc
+++ b/content/about/clojureclr.adoc
@@ -15,4 +15,4 @@ This project is a native implementation of Clojure on the Common Language Runtim
 ClojureCLR is programmed in C# (and Clojure itself) and makes use of Microsoft's Dynamic Language Runtime (DLR).
 
 * https://github.com/clojure/clojure-clr[ClojureCLR Home] 
-* https://github.com/clojure/clojure-clr/wiki/Getting-binaries[Downloading Binaries] 
+* https://github.com/clojure/clojure-clr/wiki/Getting-started[Getting started] 


### PR DESCRIPTION
Replaced with the getting started guide, which includes instructions for getting the binaries.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
