### PR TITLE
Replace link to very outdated clojure-doc.org page

### DIFF
--- a/content/guides/editors.adoc
+++ b/content/guides/editors.adoc
@@ -25,7 +25,7 @@ The main Emacs modes to be aware of are:
 
 Some places to start:
 
-* https://clojure-doc.org/articles/tutorials/emacs/[Emacs installation guide] - includes clojure-mode and CIDER
+* https://www.gnu.org/software/emacs/download.html[GNU Emacs - download and install] - the official GNU Emacs page
 * https://practical.li/spacemacs/install-spacemacs/[Practicalli guide to Spacemacs], a community driven Emacs configuration for Clojure - includes clojure-mode and CIDER
 * https://prelude.emacsredux.com/en/latest/[Prelude] - an Emacs configuration for Emacs beginners, not specific to Clojure, but includes Clojure support (clojure-mode, CIDER)
 * https://aquamacs.org/[Aquamacs] - Aquamacs is Emacs designed for the Mac native user in mind and is sufficient for a minimalist Clojure environment when paired with inf-clojure mode


### PR DESCRIPTION
The Emacs page on clojure-doc.org is very outdated and is going to be retired. I propose linking to the official download/install page as a replacement.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
