### PR TITLE
Remove broken clojure-doc.org link

### DIFF
--- a/content/community/tools.adoc
+++ b/content/community/tools.adoc
@@ -16,7 +16,6 @@ Community volunteers maintain <<xref/../../guides/getting_started#,Getting Start
 ** https://github.com/clojure-emacs/clojure-mode[clojure-mode] - an Emacs major mode that provides font-lock (syntax highlighting), indentation, navigation and refactoring support for the Clojure(Script)
 ** https://github.com/clojure-emacs/inf-clojure[inf-clojure] - provides basic interaction with a Clojure subprocess (REPL), based on ideas from the popular inferior-lisp package
 ** Installation and configuration guides
-*** http://clojure-doc.org/articles/tutorials/emacs.html[clojure-doc installation guide]
 *** https://www.braveclojure.com/basic-emacs/[Clojure for the Brave and True installation guide]
 *** https://practicalli.github.io/spacemacs/[Practicalli guide to Spacemacs]
 ** Distributions and Clojure-friendly configuration setups


### PR DESCRIPTION
Since clojure-doc.org was resurrected as GitHub pages, the URLs changed and this link was broken. Since the Emacs page on clojure-doc.org is going away and I already submitted a PR for the editors page on clojure.org, I think it makes sense to just remove this old link instead of trying to replace it with something else.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
