### PR TITLE
Update repl_and_main.adoc

### DIFF
--- a/content/reference/repl_and_main.adoc
+++ b/content/reference/repl_and_main.adoc
@@ -184,14 +184,19 @@ A socket server will be started for each JVM system property like "clojure.serve
 
 Additionally, there is a repl function provided that is slightly customized for use with the socket server in https://clojure.github.io/clojure/clojure.core-api.html#clojure.core.server/repl[clojure.core.server/repl].
 
-For example, to just launch a repl and also start a socket server with a repl listener:
+Following is an example of starting a socket server with a repl listener. This can be added to any existing Clojure program to allow it to accept external REPL clients via a local connection to port 5555.
+
+[source,shell]
+----
+-Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"
+----
+
+With the Clojure CLI this could be done with the `-J` flag to pass the option to the JVM, as:
 
 [source,shell]
 ----
 clj -J-Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"
 ----
-
-where the `-J` is used to pass the "-D..." option to the JVM. The `-Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"` can be added to any existing Clojure program in the `:jvm-opts` of its `deps.edn` file, which will allow it to accept external REPL clients via a local connection to port 5555.
 
 An example client you can use to connect to this repl remotely is telnet:
 

--- a/content/reference/repl_and_main.adoc
+++ b/content/reference/repl_and_main.adoc
@@ -184,12 +184,14 @@ A socket server will be started for each JVM system property like "clojure.serve
 
 Additionally, there is a repl function provided that is slightly customized for use with the socket server in https://clojure.github.io/clojure/clojure.core-api.html#clojure.core.server/repl[clojure.core.server/repl].
 
-Following is an example of starting a socket server with a repl listener. This can be added to any existing Clojure program to allow it to accept external REPL clients via a local connection to port 5555.
+For example, to just launch a repl and also start a socket server with a repl listener:
 
 [source,shell]
 ----
--Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"
+clj -J-Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"
 ----
+
+where the `-J` is used to pass the "-D..." option to the JVM. The `-Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"` can be added to any existing Clojure program in the `:jvm-opts` of its `deps.edn` file, which will allow it to accept external REPL clients via a local connection to port 5555.
 
 An example client you can use to connect to this repl remotely is telnet:
 


### PR DESCRIPTION
This change further explains how to use a socket server in Clojure.

I found that I was not able to run one reading the documentation. This change adds a working example which is straightforward to try, even for someone not as familiar with the JVM as I am.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
