### PR TITLE
Remove broken link from repl guide

### DIFF
--- a/content/guides/repl/launching_a_basic_repl.adoc
+++ b/content/guides/repl/launching_a_basic_repl.adoc
@@ -98,21 +98,3 @@ Find by Name: (find-name "part-of-name-here")
               (user/clojuredocs "ns-here" "name-here")
 boot.user=>
 ----
-
-== Using Java and the Clojure JAR
-
-If you have <<xref/../../getting_started#_other_ways_to_run_clojure,downloaded and built Clojure>>,
- you can use Java to launch a Clojure REPL:
-
-[source,shell]
-----
-java -jar clojure.jar
-----
-
-You should see output like the following:
-
-[source,clojure-repl]
-----
-Clojure 1.9.0
-user=>
-----


### PR DESCRIPTION
"Other ways to run Clojure" was removed from [the getting started guide](https://github.com/clojure/clojure-site/blob/master/content/guides/getting_started.adoc) in 3ed1287c38d0edad6185728a796a48d809e29005

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
