### PR TITLE
Fix broken EPL-1.0 link in license.adoc

### DIFF
--- a/content/community/license.adoc
+++ b/content/community/license.adoc
@@ -7,4 +7,4 @@ Rich Hickey
 
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
-The use and distribution terms for this software are covered by the http://opensource.org/licenses/eclipse-1.0.php[Eclipse Public License 1.0], which can be found in the file epl-v10.html at the root of this distribution. By using this software in any fashion, you are agreeing to be bound by the terms of this license. You must not remove this notice, or any other, from this software.
+The use and distribution terms for this software are covered by the https://opensource.org/license/epl-1-0/[Eclipse Public License 1.0], which can be found in the file epl-v10.html at the root of this distribution. By using this software in any fashion, you are agreeing to be bound by the terms of this license. You must not remove this notice, or any other, from this software.


### PR DESCRIPTION
Link now points to correct OSI page for EPL-1.0, previously resulted in page-not-found.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?

Out of interest, does anyone know why Clojure has not updated to EPL v2.0? Might be worth putting a teeny-tiny FAQ on this page.