### PR TITLE
Describe deps and cli "Aliases" better

### DIFF
--- a/content/reference/deps_and_cli.adoc
+++ b/content/reference/deps_and_cli.adoc
@@ -263,7 +263,11 @@ Coordinates can take several forms depending on the coordinate type:
 
 == Aliases
 
-Aliases give a name to a data structure that can be used either by the Clojure CLI itself or other consumers of deps.edn. They are defined in the `:aliases` section of the config file. These Clojure CLI subprocesses use data which can be read from aliases:
+Aliases give a name to a data structure that can be used either by the Clojure CLI itself or other consumers of deps.edn. They are defined in the `:aliases` section of the config file. Clojure CLI subprocesses such as <<deps_and_cli#_basis_and_classpath,Basis and classpath>> operations use data which can be read from aliases.
+
+Some aliases, like `:test` and `:deps` are built into the root deps.edn file. Others may be defined across various <<deps_and_cli#deps_sources,deps.edn souces>>. Note that the _alias_ `:deps` is different from the _top level key_ `:deps`, which is used to define external <<deps_and_cli#_dependencies,dependencies>>.
+
+The `:deps` alias provides <<deps_and_cli#_other_programs,additional programs>> we can run in the current deps.edn environment; e.g. `clj -X:deps aliases` to print all aliases available.
 
 == Other keys
 


### PR DESCRIPTION
The paragraph trailed off at "These Clojure CLI subprocesses use data which can be read from aliases:". Now a cross-reference explains "subprocesses".

The section also disambiguates the top level keyword `:deps` from the built in alias `:deps`. The information exists elsewhere in the reference page, but was not obvious in the Aliases section.

Finally, the section surfaces the fact that `:deps` provides additional programs for the user's perusal. Alias name printing being a handy one.

- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement? ref: my github user `adityaathalye` at https://clojure.org/dev/contributors
- [X] Have you verified your asciidoc markup is correct?