### PR TITLE
fix typo: "scoket" REPL

### DIFF
--- a/content/reference/repl_and_main.adoc
+++ b/content/reference/repl_and_main.adoc
@@ -191,7 +191,7 @@ Following is an example of starting a socket server with a repl listener. This c
 -Dclojure.server.repl="{:port 5555 :accept clojure.core.server/repl}"
 ----
 
-With the Clojure CLI, use `-J` flag to pass the option to the JVM (note that this will also start a local REPL in addition to the scoket REPL):
+With the Clojure CLI, use `-J` flag to pass the option to the JVM (note that this will also start a local REPL in addition to the socket REPL):
 
 [source,shell]
 ----


### PR DESCRIPTION
fixes scoket/socket typo

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
