### PR TITLE
Clarify dev_startup_time w.r.t. already required nss

### DIFF
--- a/content/guides/dev_startup_time.adoc
+++ b/content/guides/dev_startup_time.adoc
@@ -24,12 +24,17 @@ The `compile` function takes a namespace symbol and compiles that namespace and 
 
 Subsequently, when any of those compiled namespaces are required, the class file will be loaded, rather than the original `.clj` file. If a source file is updated (and thus newer), it will be loaded instead. Periodically, you will need to re-compile to account for new dependencies or changing code.
 
-One special case is the `user.clj` file loaded automatically by the Clojure runtime, before any other code is loaded. If you are using a `user.clj` in dev, you need to force a reload because it has already been loaded automatically:
+NOTE: Compilation happens as a side-effect of loading a namespace, and thus has no effect on already required ones. Use `*compile-files*` with `:reload-all` as suggested below to compile already loaded namespaces.
+
+One special case is the `user.clj` file loaded automatically by the Clojure runtime, before any other code is loaded. (Though this applies equally to compiling any namespace that has already been loaded into the REPL.) If you are using a `user.clj` in dev, you need to force a reload because it has already been loaded automatically:
 
 [source,clojure]
 ----
-(binding [*compile-files* true] (require 'user :reload-all))
+(binding [*compile-files* true] ; <1>
+  (require 'user :reload-all))  ; <2>
 ----
+<1> Tell Clojure to compile any namespace it is loading
+<2> Tell Clojure to reload this and all required namespaces
 
 That's it! This technique can substantially reduce your startup time during development, particularly as the number of dependencies you load increases.
 


### PR DESCRIPTION
It wasn't clear to me at all that compile only happens when loading a ns for the first time / force reloading it. HereI try to clarify this for the next person.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
