### PR TITLE
Fix typo in core-async rationale: macro <<! should be <!!

### DIFF
--- a/content/news/2013/06/28/clojure-clore-async-channels.adoc
+++ b/content/news/2013/06/28/clojure-clore-async-channels.adoc
@@ -57,7 +57,7 @@ There are analogous operations for use on ordinary threads - http://clojure.gith
 
 === Mixing modes
 
-You can put on a channel from either flavor of `>!`/`>!!` and similarly take with either of `<!`/`<<!` in any combination, i.e. the channel is oblivious to the nature of the threads which use it.
+You can put on a channel from either flavor of `>!`/`>!!` and similarly take with either of `<!`/`<!!` in any combination, i.e. the channel is oblivious to the nature of the threads which use it.
 
 === alt
 


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
