### PR TITLE
Mismatched paren in tools_build.adoc

### DIFF
--- a/content/guides/tools_build.adoc
+++ b/content/guides/tools_build.adoc
@@ -168,7 +168,7 @@ An example build for a compiled uberjar will look like this:
   (b/uber {:class-dir class-dir
            :uber-file uber-file
            :basis @basis
-           :main 'my.lib.main})))
+           :main 'my.lib.main}))
 ----
 
 This example directs `compile-clj` to compile the main namespace (by default source will be loaded from the basis :paths). Compilation is transitive and all namespaces loaded by the compiled namespace will also be compiled. You may need to add additional namespaces if code is dynamically or optionally loaded.


### PR DESCRIPTION
- [X] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [X] Have you signed the Clojure Contributor Agreement?
- [X] Have you verified your asciidoc markup is correct?
