### PR TITLE
remove empty cask, use temurin[at]21

### DIFF
--- a/content/guides/install_clojure.adoc
+++ b/content/guides/install_clojure.adoc
@@ -130,8 +130,7 @@ To use the Adoptium Temurin installers:
 
 On Mac, you can also install Temurin using brew:
 
-* `brew tap homebrew/cask-versions` - add the cask-versions tap to Homebrew
-* `brew install --cask temurin21` - install Temurin 21 (formerly AdoptOpenJDK)
+* `brew install --cask temurin@21` - install Temurin 21 (formerly AdoptOpenJDK)
 
 Check your Java version by running `java --version`. If that's not Temurin 21, then you may then need to add `java` to your `PATH`:
 


### PR DESCRIPTION
When following this guide today I got back the following errors: 

```
brew tap homebrew/cask-versions
Error: homebrew/cask-versions was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

and then 
```
 brew install --cask temurin21
Warning: Cask 'temurin21' is unavailable: No Cask with this name exists.

==> Searching for similarly named casks...
==> Casks
temurin               temurin@11            temurin@17            temurin@19            temurin@20            temurin@21            temurin@8

```

pointing to `temurin@21` works, hence that change

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
