### PR TITLE
Java interop: type hinting an array

### DIFF
--- a/content/reference/java_interop.adoc
+++ b/content/reference/java_interop.adoc
@@ -297,6 +297,14 @@ For function return values, the type hint can be placed before the parameter vec
 -> #user/hinted
 ----
 
+For type hints on arrays, see <<TypeAliases>> below for primitive arrays. For non-primitive arrays you can use
+the Java array class name (`"[L" + class name + ";"`):
+
+[source,clojure]
+----
+(defn foo [^"[Ljava.lang.String;" strs])
+----
+
 [[TypeAliases]]
 == Aliases
 


### PR DESCRIPTION
The section on type hints does not make it clear how to do this for arrays (unless you know to look at "Aliases" for the primitive ones), especially for non-primitive ones.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
