### PR TITLE
Rename DocSolver to Basil Inc in companies.adoc

### DIFF
--- a/content/community/companies.adoc
+++ b/content/community/companies.adoc
@@ -50,6 +50,7 @@ Also, check out the <<success_stories#,Clojure Success Stories>> and <<community
 * baresquare
 * Barracuda
 * BaseFEX
+* Basil Inc
 * Beanstalk
 * Beary Innovative
 * Belit
@@ -144,7 +145,6 @@ Also, check out the <<success_stories#,Clojure Success Stories>> and <<community
 * Diagnosia
 * Discendum ltd
 * Dividend Finance
-* DocSolver
 * Doctor Evidence
 * Doctronic
 * DOV-E


### PR DESCRIPTION
Our company DocSolver was renamed to Basil Inc, as can be seen at https://docsolver.com.