### PR TITLE
tools_build: inconsistent spelling of "path[s] roots"

### DIFF
--- a/content/guides/tools_build.adoc
+++ b/content/guides/tools_build.adoc
@@ -47,7 +47,7 @@ So executing `clj -T:build jar` will use an effective classpath here of:
 * org.clojure/clojure (from the root deps.edn `:deps`) and transitive deps
 * org.clojure/tools.build (from the `:build` alias `:deps`) and transitive deps
 
-The `:ns-default` specifies the default Clojure namespace to find the function specified on the classpath. Because the only local path is the default `"."`, we should expect to find the build program at `build.clj` in the root of our project. Note that the path roots (via the `:build` alias `:paths`) and the namespace of the build program itself relative to those paths roots are fully under your control. You may wish to put them in a subdirectory of your project too.
+The `:ns-default` specifies the default Clojure namespace to find the function specified on the classpath. Because the only local path is the default `"."`, we should expect to find the build program at `build.clj` in the root of our project. Note that the path roots (via the `:build` alias `:paths`) and the namespace of the build program itself relative to those path roots are fully under your control. You may wish to put them in a subdirectory of your project too.
 
 And then finally, on the command line we specify the function to run in the build, here `jar`. That function will be executed in the `build` namespace, and passed a map built using the same arg passing style as `-X` - args are provided as alternating keys and values.
 
@@ -227,7 +227,7 @@ For example, consider a parameterization that includes an extra set of dev resou
     params))
 ----
 
-The other aspects of deps.edn and invocation remain the same. 
+The other aspects of deps.edn and invocation remain the same.
 
 Invocation that activates :dev environment will look like this:
 


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?

The form `path roots` appears twice in this sentence, with two different spellings. I believe they should be spelled the same way, and the first one is correct (singular `path` with multiple `roots`). Happy to switch the change if the latter assumption is incorrect.