### PR TITLE
Escape all URLs containing `--` and `'`

### DIFF
--- a/content/news/2021/06/11/deref.adoc
+++ b/content/news/2021/06/11/deref.adoc
@@ -21,7 +21,7 @@ We have a bumper crop of Clojure-related podcast episodes this week, put these i
 
 * https://www.cognitect.com/cognicast/160[Cognicast] - Christian Romney interviews Jarrod Taylor from the Datomic team
 * https://getsmarterandmakestuff.com/2021/06/06/podcast-episode-005-michael-fogus/[Get Smarter and Make Stuff] - Craig Andera interviews Michael Fogus from the Clojure core team
-* https://anchor.fm/lostinlambduhhs/episodes/puredanger-Alex-Miller--Clojures-Cool-dad-e12botj[Lost in Lambduhhs] - Jordan Miller interviews Alex Miller from the Clojure core team
+* link:++https://anchor.fm/lostinlambduhhs/episodes/puredanger-Alex-Miller--Clojures-Cool-dad-e12botj++[Lost in Lambduhhs] - Jordan Miller interviews Alex Miller from the Clojure core team
 * https://clojurescriptpodcast.com/[ClojureScript Podcast] - Jacek Schae interviews Tommi Reiman about Malli
 * https://soundcloud.com/defn-771544745/72-chris-badahdah-from-phoenix[defn] - Vijay Kiran and Ray McDermott interview Chris Badahdah about Portal  
 

--- a/content/news/2021/06/25/deref.adoc
+++ b/content/news/2021/06/25/deref.adoc
@@ -40,7 +40,7 @@ Over the last couple years, the https://calva.io/[Calva] team has been putting a
 * https://danielgregoire.dev/posts/2021-06-18-open-closed-systems-clojure/[Open and Closed Systems with Clojure] - Daniel Gregoire 
 * https://blog.jakubholy.net/2021/simplicity/[What is simplicity in programming and why does it matter?] - Jakub Holý
 * https://www.michaelnygard.com/blog/2021/06/counterfactuals-are-not-causality/[Counterfactuals are not Causality] - Michael Nygard - not about Clojure but worth a read!
-* https://robhaisfield.com/notes/how-i'm-learning-clojure[How I'm learning Clojure] - Rob Haisfield
+* link:++https://robhaisfield.com/notes/how-i'm-learning-clojure++[How I'm learning Clojure] - Rob Haisfield
 * https://ostash.dev/posts/2021-06-18-clojure-metadata/[Clojure metadata] - Roman Ostash
 * https://ostash.dev/posts/2021-06-24-edn-data-notation/[Data notation in Clojure] - Roman Ostash
 * https://blog.jakubholy.net/2021/specific-vs-general-cryogen/[Specific vs. general: Which is better?] - Jakub Holý

--- a/content/news/2021/10/08/deref.adoc
+++ b/content/news/2021/10/08/deref.adoc
@@ -42,7 +42,7 @@ I've been working on several things, but one ongoing thing we're exploring is so
 
 * https://www.cognitect.com/cognicast/162[Cognicast] - Craig Andera	
 * https://www.therepl.net/episodes/42/[The REPL] - Faster JSON parsing with Erik Assum	
-* https://anchor.fm/lostinlambduhhs/episodes/lambduhh--Jordan-Miller-I-e185vtp[:lambduhh (= Jordan Miller "I" )] - Jordan Miller
+* link:++https://anchor.fm/lostinlambduhhs/episodes/lambduhh--Jordan-Miller-I-e185vtp++[:lambduhh (= Jordan Miller "I" )] - Jordan Miller
 * https://clojurescriptpodcast.com/[ClojureScript podcast] - Config with Alexander Yakushev	
 * https://lispcast.com/the-humble-programmer/[The Humble Programmer] - Eric Normand
 * https://lispcast.com/programmer-as-navigator/[Programmer as Navigator] - Eric Normand

--- a/content/news/2022/05/27/deref.adoc
+++ b/content/news/2022/05/27/deref.adoc
@@ -12,7 +12,7 @@ Welcome to the Clojure Deref! This is a weekly link/news roundup for the Clojure
 * https://soundcloud.com/defn-771544745/84-debbie-and-wilker-lucio[#84 - Debbie and Wilker Lúcio] - defn podcast
 * https://soundcloud.com/clojurestream/nbb-with-michiel-borkent[E71 nbb with Michiel Borkent] - ClojureStream Podcast
 * https://www.youtube.com/watch?v=AvtSFWT5rHs[Clojure Transducers: optimizing my submission to Steve Yegge's farmer/dog/chicken/grain challenge] - Fred Overflow
-* https://anchor.fm/lostinlambduhhs/episodes/ray-mcdermott-Has-birthed--a-repl-acement-e1iuoom[:ray-mcdermott (Has birthed, a repl-acement??)] - Lost in Lambduhhs
+* link:++https://anchor.fm/lostinlambduhhs/episodes/ray-mcdermott-Has-birthed--a-repl-acement-e1iuoom++[:ray-mcdermott (Has birthed, a repl-acement??)] - Lost in Lambduhhs
 
 == Blogs
 

--- a/content/news/2022/09/09/deref.adoc
+++ b/content/news/2022/09/09/deref.adoc
@@ -15,7 +15,7 @@ I will mention the Clojurists Together https://www.clojuriststogether.org/news/q
 
 == Podcasts and videos
 
-* https://anchor.fm/lostinlambduhhs/episodes/janet-a-carr-Ms--Free-lance-a-lot-frees-her-SaaSy-thoughts-e1niuf3[:janet-a-carr (Ms. Free-lance-a-lot frees her SaaSy thoughts)] - Lost in Lambduhhs by Jordan Miller
+* link:++https://anchor.fm/lostinlambduhhs/episodes/janet-a-carr-Ms--Free-lance-a-lot-frees-her-SaaSy-thoughts-e1niuf3++[:janet-a-carr (Ms. Free-lance-a-lot frees her SaaSy thoughts)] - Lost in Lambduhhs by Jordan Miller
 * https://www.youtube.com/watch?v=ARqU40IHiwo[Starting a fresh Clojure project with Neovim REPL driven development] - Oliver Caldwell
 * https://www.youtube.com/watch?v=QTgdoZ1LSzk[Clojure visual-tools meeting 11: tooling for learning resources, a peek into Data Rabbit] - Sci Cloj
 * https://www.youtube.com/watch?v=pImaXoTPWWA[Transform MS Office into Cloud-savvy Linked Data Microservices With Clojure on .NET (by Bob Calco)] - London Clojurians

--- a/content/news/2023/11/10/deref.adoc
+++ b/content/news/2023/11/10/deref.adoc
@@ -26,7 +26,7 @@ Welcome to the Clojure Deref! This is a weekly link/news roundup for the Clojure
 New releases and tools this week:
 
 * https://github.com/oliyh/carmine-streams[carmine-streams] 0.2.2 - Utility functions for working with Redis streams in carmine
-* https://github.com/overtone/overtone[overtone] https://github.com/overtone/overtone/blob/master/CHANGELOG.md#0110-2023-11-02--2907605ba[0.11.0] - Collaborative Programmable Music
+* https://github.com/overtone/overtone[overtone] link:++https://github.com/overtone/overtone/blob/master/CHANGELOG.md#0110-2023-11-02--2907605ba++[0.11.0] - Collaborative Programmable Music
 * https://github.com/cnuernber/ham-fisted[ham-fisted] https://github.com/cnuernber/ham-fisted/blob/master/CHANGELOG.md#2011[2.010] - High performance HAMT
 * https://github.com/alexander-yakushev/compliment[compliment] https://github.com/alexander-yakushev/compliment/blob/master/CHANGELOG.md#050-2023-11-08[0.5.0] - Clojure completion library that you deserve
 * https://github.com/zmedelis/hfds-clj[hfds-clj] 2023.11.05 - Access to HuggingFace datasets via Clojure

--- a/content/news/2023/11/17/deref.adoc
+++ b/content/news/2023/11/17/deref.adoc
@@ -30,7 +30,7 @@ New releases and tools this week:
 
 * https://github.com/squint-cljs/squint[squint] https://github.com/squint-cljs/squint/blob/main/CHANGELOG.md#0448-2023-11-17[0.4.48] - ClojureScript syntax to JavaScript compiler
 * https://github.com/behrica/msal-helper[msal-helper]  - Just a bit of re-usable code to obtain and cache identity tokens comming from Azure Identtity
-* https://github.com/grzm/awyeah-api[awyeah-api] https://github.com/grzm/awyeah-api/blob/main/CHANGES.markdown#0882--5ecad02--2023-11-14[0.8.82] - Cognitect's aws-api for babashka
+* https://github.com/grzm/awyeah-api[awyeah-api] link:++https://github.com/grzm/awyeah-api/blob/main/CHANGES.markdown#0882--5ecad02--2023-11-14++[0.8.82] - Cognitect's aws-api for babashka
 * https://github.com/taoensso/tempel[tempel] https://github.com/taoensso/tempel/releases/tag/v1.0.0-alpha1[1.0.0-alpha1] - Data security framework for Clojure
 * https://github.com/fractl-io/fractl[fractl] 0.4.7 - Generative AI-powered Programming Language
 * https://github.com/quil/quil[quil] https://github.com/quil/quil/blob/master/RELEASE-NOTES.md#431323[4.3.1323] - Quil

--- a/content/news/2023/12/08/deref.adoc
+++ b/content/news/2023/12/08/deref.adoc
@@ -36,7 +36,7 @@ Welcome to the Clojure Deref! This is a weekly link/news roundup for the Clojure
 
 New releases and tools this week:
 
-* https://github.com/grzm/awyeah-api[awyeah-api] https://github.com/grzm/awyeah-api/blob/main/CHANGES.markdown#0884--e551334--2023-12-02[0.8.84] - Cognitect's aws-api for babashka
+* https://github.com/grzm/awyeah-api[awyeah-api] link:++https://github.com/grzm/awyeah-api/blob/main/CHANGES.markdown#0884--e551334--2023-12-02++[0.8.84] - Cognitect's aws-api for babashka
 * https://github.com/eval/deps-try[deps-try] https://github.com/eval/deps-try/blob/master/CHANGELOG.md#v0100-2023-12-04[0.10.0] - Try out Clojure libraries via rebel-readline
 * https://github.com/raystubbs/zero[zero]  - Build web components in CLJS
 * https://github.com/SURFnet/apie[apie] 0.1.0 - Apie 🙈 OpenAPI Service Validator

--- a/content/news/2024/02/02/deref.adoc
+++ b/content/news/2024/02/02/deref.adoc
@@ -38,14 +38,14 @@ New releases and tools this week:
 * https://github.com/borkdude/edamame[edamame] https://github.com/borkdude/edamame/blob/master/CHANGELOG.md#1424[1.4.24] - Configurable EDN/Clojure parser with location metadata
 * https://github.com/mpenet/hirundo[hirundo] 0.1.31 - Helidon 4.x RING adapter - using loom/java21+
 * https://github.com/SURFnet/apie[apie] https://github.com/SURFnet/apie/blob/main/changelog.md#v020[0.2.0] - OpenAPI Service Validator
-* https://github.com/cognitect-labs/aws-api[aws-api] https://github.com/cognitect-labs/aws-api/blob/main/CHANGES.md#08692--2024-01-31[0.8.692] - AWS, data driven
+* https://github.com/cognitect-labs/aws-api[aws-api] link:++https://github.com/cognitect-labs/aws-api/blob/main/CHANGES.md#08692--2024-01-31++[0.8.692] - AWS, data driven
 * https://github.com/clj-commons/marginalia[marginalia] https://github.com/clj-commons/marginalia/releases/tag/v0.9.2[0.9.2] - Ultra-lightweight literate programming for clojure inspired by docco
 * https://github.com/clj-commons/lein-marginalia[lein-marginalia] 0.9.2 - A Marginalia plugin to Leiningen
 * https://github.com/clojure-lsp/clojure-lsp[clojure-lsp] https://github.com/clojure-lsp/clojure-lsp/releases/tag/2024.02.01-11.01.59[2024.02.01-11.01.59] - Clojure & ClojureScript Language Server (LSP) implementation
 * https://github.com/mynomoto/sci-koans[sci-koans]  - A port of Clojurescript koans to SCI translated to Portuguese
 * https://github.com/scicloj/clay[clay] https://github.com/scicloj/clay/blob/main/CHANGELOG.md#2-alpha77---2024-02-02[2-alpha77] - A tiny Clojure tool for dynamic workflow of data visualization and literate programming
 * https://github.com/babashka/nbb[nbb] https://github.com/babashka/nbb/blob/main/CHANGELOG.md#12180-2024-01-29[1.2.180] - Scripting in Clojure on Node.js using SCI
-* https://github.com/kbosompem/bb-excel[bb-excel] https://github.com/kbosompem/bb-excel/blob/main/CHANGELOG.md#011--2024-02-01[0.1.1] - Read Excel Files in babashka scripts
+* https://github.com/kbosompem/bb-excel[bb-excel] link:++https://github.com/kbosompem/bb-excel/blob/main/CHANGELOG.md#011--2024-02-01++[0.1.1] - Read Excel Files in babashka scripts
 * https://github.com/imrekoszo/polylith-kaocha[polylith-kaocha] https://github.com/imrekoszo/polylith-kaocha/releases/tag/v0.8.4[0.8.4] - Kaocha-based test runner for Polylith
 * https://github.com/babashka/json[json] https://github.com/babashka/json/blob/main/CHANGELOG.md#016[0.1.6] - JSON abstraction library
 * https://github.com/soulspace-org/overarch[overarch] https://github.com/soulspace-org/overarch/blob/main/Changelog.md#version-080[0.8.0] - A data driven description of software architecture based on UML and the C4 model

--- a/content/news/2024/02/26/deref.adoc
+++ b/content/news/2024/02/26/deref.adoc
@@ -44,7 +44,7 @@ New releases and tools this week:
 * https://github.com/polyfy/polylith[polylith] https://github.com/polyfy/polylith/releases/tag/v0.2.19[0.2.19] - A tool used to develop Polylith based architectures in Clojure
 * https://github.com/fulcrologic/guardrails[guardrails] 1.2.3 - Efficient, hassle-free function call validation with a concise inline syntax for clojure.spec and Malli
 * https://github.com/replikativ/mesalog[mesalog] 0.2.253 - CSV data loader for Datalog databases
-* https://github.com/lambdaisland/cli[cli] https://github.com/lambdaisland/cli/blob/main/CHANGELOG.md#0424-2024-02-17--5a1e316[0.4.24] - Opinionated command line argument handling, with excellent support for subcommands
+* https://github.com/lambdaisland/cli[cli] link:++https://github.com/lambdaisland/cli/blob/main/CHANGELOG.md#0424-2024-02-17--5a1e316++[0.4.24] - Opinionated command line argument handling, with excellent support for subcommands
 * https://github.com/lambdaisland/deep-diff2[deep-diff2] https://github.com/lambdaisland/deep-diff2/releases/tag/v2.11.216[2.11.216] - Deep diff Clojure data structures and pretty print the result
 * https://github.com/tonsky/clj-reload[clj-reload] https://github.com/tonsky/clj-reload/blob/main/CHANGELOG.md#013---feb-21-2024[0.1.3] - Smarter way to reload Clojure code
 * https://github.com/igrishaev/pg2[pg2] https://github.com/igrishaev/pg2/blob/master/CHANGELOG.md#013[0.1.3] - A fast PostgreSQL driver for Clojure

--- a/content/news/2024/06/01/deref.adoc
+++ b/content/news/2024/06/01/deref.adoc
@@ -9,7 +9,7 @@ Welcome to the Clojure Deref! This is a weekly link/news roundup for the Clojure
 
 == Podcasts and videos
 
-* https://podcasters.spotify.com/pod/show/lostinlambduhhs/episodes/arne-brasseur-tea--travel--taoism-and-HoC-e2kbq1p[:arne-brasseur (tea, travel, taoism and HoC)] - Lost in Lambduhhs
+* link:++https://podcasters.spotify.com/pod/show/lostinlambduhhs/episodes/arne-brasseur-tea--travel--taoism-and-HoC-e2kbq1p++[:arne-brasseur (tea, travel, taoism and HoC)] - Lost in Lambduhhs
 * https://www.youtube.com/watch?v=EvAFEC6n7NI[FDB - a reactive database environment for your files (by Filipe Silva)] - London Clojurians
 
 == Blogs, articles, and projects

--- a/content/news/2024/07/17/deref.adoc
+++ b/content/news/2024/07/17/deref.adoc
@@ -12,7 +12,7 @@ Welcome to the Clojure Deref! This is a weekly link/news roundup for the Clojure
 * https://www.youtube.com/watch?v=XKHFDncWFTI[Clojure visual-tools meeting 25 - keg-party & HTMX] - Sci Cloj
 * https://www.youtube.com/watch?v=eBf7qb-97Bs[Pedestal 9 – API that does nothing] - Clojure Diary
 * https://www.youtube.com/watch?v=S8N5je3nN0c[Coding Injee – First steps] - Clojure Diary
-* https://podcasters.spotify.com/pod/show/lostinlambduhhs/episodes/sophia-velten-category-theory--monads--kung-fu-e2lvg8b[:sophia-velten (category theory, monads, kung-fu) by Lost in Lambduhhs] - LiLpodcast
+* link:++https://podcasters.spotify.com/pod/show/lostinlambduhhs/episodes/sophia-velten-category-theory--monads--kung-fu-e2lvg8b++[:sophia-velten (category theory, monads, kung-fu) by Lost in Lambduhhs] - LiLpodcast
 * https://www.youtube.com/watch?v=u7dtFGL4Sgg[Meetup: Collaborative Learning – Sente] - Los Angeles Clojure Users Group
 
 == Blogs, articles, and projects

--- a/content/news/2024/10/11/deref.adoc
+++ b/content/news/2024/10/11/deref.adoc
@@ -20,7 +20,7 @@ Welcome to the Clojure Deref! This is a weekly link/news roundup for the Clojure
 * https://scicloj.github.io/blog/clojurists-together-project-scicloj-community-building-september-2024-update/[Clojurists Together project - Scicloj community building - September 2024 update] - Daniel Slutsky
 * https://biffweb.com/p/rocksdb-indexes-yakread/[RocksDB indexes are done, open-sourcing Yakread next] - Jacob O'Bryant
 * https://andersmurphy.com/2024/10/07/clojure-synchronous-server-sent-events-with-virtual-threads-and-channels.html[Clojure: Synchronous server sent events with virtual threads and channels] - Anders Murphy
-* https://www.ovistoica.com/blog/20241009T084633--the-best-way-to-handle-svg-icons-in-fullstack-clojure-project__blog_clojure_clojurescript_web[The Best Way To Handle SVG Icons in FullStack Clojure Project] - Ovi Stoica
+* link:++https://www.ovistoica.com/blog/20241009T084633--the-best-way-to-handle-svg-icons-in-fullstack-clojure-project__blog_clojure_clojurescript_web++[The Best Way To Handle SVG Icons in FullStack Clojure Project] - Ovi Stoica
 
 == Libraries and Tools
 

--- a/content/news/2025/06/27/deref.adoc
+++ b/content/news/2025/06/27/deref.adoc
@@ -23,10 +23,10 @@ The https://2025.clojure-conj.org/[Clojure/conj] 2025 https://2025.clojure-conj.
 * https://code.thheller.com/blog/shadow-cljs/2025/06/24/what-the-heck-just-happened.html[What The Heck Just Happened?] - Thomas Heller
 * https://yamlscript.org/blog/2025-06-24/how-does-ys-work/[How Does YS Work? - YS — YAML Done Wisely] - Ingy döt Net
 * https://code.thheller.com/blog/shadow-cljs/2025/06/25/what-the-heck-are-you-talking-about.html[What The Heck Are You Talking About?] - Thomas Heller
-* https://yamlscript.org/blog/2025-06-25/ai--clojure-functions-in-yaml/[AI + Clojure Functions in YAML - YS — YAML Done Wisely] - Ingy döt Net
+* link:++https://yamlscript.org/blog/2025-06-25/ai--clojure-functions-in-yaml/++[AI + Clojure Functions in YAML - YS — YAML Done Wisely] - Ingy döt Net
 * https://buttondown.com/tensegritics-curiosities/archive/accelerating-maps-with-join-with/[Accelerating maps with join-with] - Christophe Grand
 * https://code.thheller.com/blog/shadow-cljs/2025/06/27/case-study-reagent-with-macro-help.html[Case Study: Reagent With Macro Help] - Thomas Heller
-* https://yamlscript.org/blog/2025-06-27/fun-fridays--rosetta-code/[Fun FridaYS — Rosetta Code - YS — YAML Done Wisely] - Ingy döt Net
+* link:++https://yamlscript.org/blog/2025-06-27/fun-fridays--rosetta-code/++[Fun FridaYS — Rosetta Code - YS — YAML Done Wisely] - Ingy döt Net
 
 == Libraries and Tools
 


### PR DESCRIPTION
- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [ ] Have you verified your asciidoc markup is correct? 
(**jbake <2.7.0-rc.7 doesn't seem to run on Apple Silicon chips. I would be grateful if someone could check that everything renders correctly.**)


The latest Deref (and others) contains links with `--`. Asciidoctor substitutes these with an em dash (`%E2%80%94`) and a zero-width space (`%E2%80%8B`) (see [their docs](https://docs.asciidoctor.org/asciidoc/latest/subs/replacements/) for all substitutions). 
This breaks many URLs. (Interestingly, spotify.com seems fine with that.)

---

Original URL: 
`https://yamlscript.org/blog/2025-06-27/fun-fridays--rosetta-code/`

The resulting URL looks like this:
`https://yamlscript.org/blog/2025-06-27/fun-fridays%E2%80%94%E2%80%8Brosetta-code/`

This can be prevented by writing:
`link:++https://yamlscript.org/blog/2025-06-27/fun-fridays--rosetta-code/++`

See [Troubleshooting Complex URLs](https://docs.asciidoctor.org/asciidoc/latest/macros/complex-urls/)

---

For future reference: I used the regex `(\S+[^-]--(?!-)\S+)(?=\[)` to find and replace occurrences in VSCode.
