### PR TITLE
Fix link to API docs in CLI Reference

### DIFF
--- a/content/reference/clojure_cli.adoc
+++ b/content/reference/clojure_cli.adoc
@@ -624,7 +624,7 @@ For example, the following can be used to print the deps tree for a `:test` alia
 clj -X:deps tree :aliases '[:test]`
 ---
 
-See https://clojure.github.io/tools.deps.cli/clojure.tools.deps.cli.api-api.html#clojure.tools.deps.cli.api/list[API docs].
+See https://clojure.github.io/tools.deps.cli/clojure.tools.deps.cli.api-api.html#clojure.tools.deps.cli.api/tree[API docs].
 
 [[deps_aliases]]
 === Alias list


### PR DESCRIPTION
The link under "Dependency tree" pointed to the `list` function, now it points to `tree`.

- [ ] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [ ] Have you signed the Clojure Contributor Agreement?
- [ ] Have you verified your asciidoc markup is correct?
