### PR TITLE
Change java.jdbc status to Inactive

### DIFF
--- a/content/dev/contrib_libs.adoc
+++ b/content/dev/contrib_libs.adoc
@@ -60,7 +60,7 @@ Status legend:
 | https://clojure.github.io/data.zip/[data.zip] | Manipulating zippers | | Stable
 | https://clojure.github.io/java.classpath/[java.classpath] | Classpath utilities | Alessandra Sierra | Stable
 | https://clojure.github.io/java.data/[java.data] | Work with Java Beans | Sean Corfield | Active
-| https://clojure.github.io/java.jdbc/[java.jdbc] | JDBC-based SQL interface | Sean Corfield | Stable
+| https://clojure.github.io/java.jdbc/[java.jdbc] | JDBC-based SQL interface | Sean Corfield | Inactive
 | https://clojure.github.io/java.jmx/[java.jmx] | JMX interface | Nick Bailey | Stable
 | https://clojure.github.io/math.combinatorics/[math.combinatorics] | Lazy sequences for common combinatorial functions | Mark Engelberg | Stable
 | https://clojure.github.io/math.numeric-tower/[math.numeric-tower] | Math functions and numeric tower | Mark Engelberg | Stable


### PR DESCRIPTION
It has been marked Stable for a long time and has had no releases in well over four years, so Inactive is more accurate.

I also want to "encourage" folks to choose `next.jdbc` instead of `java.jdbc` at this point, and the README has labeled `java.jdbc` as "Inactive" and recommended `next.jdbc` for some time.

- [x] Have you read the [guidelines for contributing](https://clojure.org/community/contributing_site)?
- [x] Have you signed the Clojure Contributor Agreement?
- [x] Have you verified your asciidoc markup is correct?
