### PR TITLE
Document top-level do behavior

### DIFF
--- a/content/reference/special_forms.adoc
+++ b/content/reference/special_forms.adoc
@@ -86,6 +86,19 @@ Evaluates _test_. If not the singular values `nil` or `false`, evaluates and yie
 
 Evaluates the expressions __expr__s in order and returns the value of the last. If no expressions are supplied, returns `nil`.
 
+When `do` appears at the top level of a file or at the REPL, each expression within it is evaluated as a separate top-level form. This means each expression is fully evaluated before the next one is compiled, so side effects from earlier expressions (such as `require` or `import`) are visible to the compiler when processing later expressions.
+
+[source,clojure]
+----
+;; This works because require is evaluated before set/difference is compiled
+(do
+  (require '[clojure.set :as set])
+  (set/difference #{1 2 3} #{1 3}))
+;;=> #{2}
+----
+
+This behavior does not apply to `do` forms nested inside other forms, where the entire enclosing form is compiled before any of it is evaluated.
+
 [[let]]
 == (`let` [ __binding__* ] __expr__*)
 


### PR DESCRIPTION
Adds a note to the `do` special form documentation explaining that at the top level, each expression is evaluated as a separate top-level form. This means side effects like `require` are visible to the compiler when processing subsequent expressions.

Includes a code example demonstrating the behavior and a note that this does not apply to `do` forms nested inside other forms.

Verified against `Compiler.java` `eval()` method: after macroexpanding, if the form is a `do`, each sub-form is recursively `eval`'d individually rather than compiled as a single unit.

Fixes #723