### PR TITLE
Fix MANPATH in custom location install examples

### DIFF
--- a/content/guides/install_clojure.adoc
+++ b/content/guides/install_clojure.adoc
@@ -62,7 +62,7 @@ You may also want to extend the MANPATH in `/etc/man_db.conf` to include the man
 
 [source]
 ----
-MANPATH_MAP /opt/infrastructure/clojure/bin /opt/infrastructure/clojure/man
+MANPATH_MAP /opt/infrastructure/clojure/bin /opt/infrastructure/clojure/share/man
 ----
 
 The `linux-install` script can be removed after installation.
@@ -94,7 +94,7 @@ You may also want to extend the MANPATH in `/etc/man_db.conf` to include the man
 
 [source]
 ----
-MANPATH_MAP /opt/infrastructure/clojure/bin /opt/infrastructure/clojure/man
+MANPATH_MAP /opt/infrastructure/clojure/bin /opt/infrastructure/clojure/share/man
 ----
 
 The `posix-install` script can be removed after installation.


### PR DESCRIPTION
Fixes the MANPATH_MAP examples in both the Linux and POSIX install sections to use `share/man` instead of `man`. The installer places man pages under `$prefix/share/man/`, not `$prefix/man/`.

Verified against the actual install location (`/usr/share/man/man1/clj.1.gz`).

Fixes #493