### PR TITLE
Fix reducers foldcat example to actually fold in parallel

### DIFF
--- a/content/reference/reducers.adoc
+++ b/content/reference/reducers.adoc
@@ -64,10 +64,10 @@ Use https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/into[in
 ----
 (into [] (r/filter even? (r/map inc (range 100000))))
 ----
-Or https://clojure.github.io/clojure/clojure.core-api.html#clojure.core.reducers/foldcat[r/foldcat]:
+Or https://clojure.github.io/clojure/clojure.core-api.html#clojure.core.reducers/foldcat[r/foldcat] to produce a foldable collection. Note the use of `vec` — seqs like those returned by `range` do not support parallel folding, so they must be converted to a vector first:
 [source,clojure]
 ----
-(r/foldcat (r/filter even? (r/map inc (range 100000))))
+(r/foldcat (r/filter even? (r/map inc (vec (range 100000)))))
 ----
 Specify a reduce function and a combine function with fold:
 [source,clojure]


### PR DESCRIPTION
The `r/foldcat` example used `(range 100000)` which returns a seq. Seqs do not implement `CollFold` and fall back to single-threaded reduce, making the example misleading on a page about parallel folding.

Wraps with `vec` so the example actually demonstrates parallel folding, and adds a note explaining the requirement.

Verified against `reducers.clj`: `Object/coll-fold` falls back to single reduce, while `IPersistentVector/coll-fold` performs parallel fork-join folding.

Fixes #377