### PR TITLE
Update url for Oslo Clojure user group

### DIFF
--- a/content/community/user_groups.adoc
+++ b/content/community/user_groups.adoc
@@ -106,7 +106,7 @@ Riviera Scala, (Twitter: https://twitter.com/riviera_func[@riviera_func])
 ** Netherlands
 *** http://amsclj.nl/[The Dutch Clojure Meetup] (Twitter: https://twitter.com/amsclj[@amsclj])
 ** Norway
-*** https://www.meetup.com/Oslo-Clojure-Meetup/[Oslo Clojure Meetup]
+*** https://www.meetup.com/clojure-oslo/[Oslo Clojure Meetup]
 ** Russia
 *** https://plus.google.com/u/0/communities/114227952963737516047[Clojure Russia]
 ** Slovakia


### PR DESCRIPTION
Just a link update. The old one doesn't exist anymore.